### PR TITLE
Handle malformed metric inputs

### DIFF
--- a/preprocessing.py
+++ b/preprocessing.py
@@ -7,23 +7,32 @@ import pandas as pd
 def convert_height_to_cm(height: str) -> float | None:
     """Convert a height value like ``6' 2\"`` to centimeters."""
     if height and height != "--":
-        feet, inches = height.split("' ")
-        inches = inches.replace('"', '')
-        return int(feet) * 30.48 + int(inches) * 2.54
+        try:
+            feet, inches = height.split("' ")
+            inches = inches.replace('"', '')
+            return int(feet) * 30.48 + int(inches) * 2.54
+        except ValueError:
+            return None
     return None
 
 
 def convert_weight_to_kg(weight: str) -> float | None:
     """Convert a weight value like ``170 lbs."`` to kilograms."""
     if weight and weight != "--":
-        return float(weight.replace(' lbs.', '')) * 0.453592
+        try:
+            return float(weight.replace(' lbs.', '')) * 0.453592
+        except ValueError:
+            return None
     return None
 
 
 def convert_reach_to_cm(reach: str) -> float | None:
     """Convert a reach measurement in inches to centimeters."""
     if reach and reach != "--":
-        return float(reach.replace('"', '')) * 2.54
+        try:
+            return float(reach.replace('"', '')) * 2.54
+        except ValueError:
+            return None
     return None
 
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from preprocessing import convert_height_to_cm, convert_weight_to_kg, convert_reach_to_cm
+
+
+def test_convert_height_to_cm_malformed():
+    assert convert_height_to_cm("--") is None
+    assert convert_height_to_cm("") is None
+    assert convert_height_to_cm("bad format") is None
+
+
+def test_convert_weight_to_kg_malformed():
+    assert convert_weight_to_kg("--") is None
+    assert convert_weight_to_kg("") is None
+    assert convert_weight_to_kg("bad format") is None
+
+
+def test_convert_reach_to_cm_malformed():
+    assert convert_reach_to_cm("--") is None
+    assert convert_reach_to_cm("") is None
+    assert convert_reach_to_cm("bad format") is None


### PR DESCRIPTION
## Summary
- Wrap height/weight/reach conversions in try/except to return `None` for unexpected formats
- Add unit tests covering malformed strings such as `"--"` or empty values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bbdd111888324a15b5154e2da5205