### PR TITLE
Use context-managed requests session for scraping

### DIFF
--- a/scraping.py
+++ b/scraping.py
@@ -1,27 +1,23 @@
 """Web scraping utilities for UFC statistics."""
 import time
 from typing import Optional
+
 import requests
 import pandas as pd
 from bs4 import BeautifulSoup
 
-# Reuse a single session for all requests to benefit from connection pooling
-session = requests.Session()
-session.headers.update(
-    {
-        "User-Agent": (
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/119.0 Safari/537.36"
-        )
-    }
-)
 
-
-def fetch(url: str, retries: int = 3, backoff: int = 1, timeout: int = 10) -> Optional[requests.Response]:
+def fetch(
+    session: requests.Session,
+    url: str,
+    retries: int = 3,
+    backoff: int = 1,
+    timeout: int = 10,
+) -> Optional[requests.Response]:
     """Perform an HTTP GET request with retries.
 
     Args:
+        session: Active :class:`requests.Session` used for the request.
         url: Target URL.
         retries: Number of retry attempts for failed requests.
         backoff: Base number of seconds to wait between retries.
@@ -49,9 +45,15 @@ def fetch(url: str, retries: int = 3, backoff: int = 1, timeout: int = 10) -> Op
     return None
 
 
-def fetch_soup(url: str, retries: int = 3, backoff: int = 1, timeout: int = 10) -> Optional[BeautifulSoup]:
+def fetch_soup(
+    session: requests.Session,
+    url: str,
+    retries: int = 3,
+    backoff: int = 1,
+    timeout: int = 10,
+) -> Optional[BeautifulSoup]:
     """Fetch a URL and return a BeautifulSoup parsed document."""
-    response = fetch(url, retries=retries, backoff=backoff, timeout=timeout)
+    response = fetch(session, url, retries=retries, backoff=backoff, timeout=timeout)
     return BeautifulSoup(response.content, "html.parser") if response else None
 
 
@@ -73,37 +75,48 @@ def scrape_fighters(timeout: int = 10, delay: float = 1.0) -> pd.DataFrame:
     full_names, heights, weights, reaches = [], [], [], []
     stances, wins, losses, draws, birthdates = [], [], [], [], []
 
-    for char in "abcdefghijklmnopqrstuvwxyz":
-        url = f"http://ufcstats.com/statistics/fighters?char={char}&page=all"
-        soup = fetch_soup(url, timeout=timeout)
-        if not soup:
-            continue
-        table = soup.select_one("table")
-        if not table:
-            continue
-        for row in table.select("tr:nth-of-type(n+2)"):
-            cols = row.find_all("td")
-            link = cols[1].find("a")
-            if not link:
+    with requests.Session() as session:
+        session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/119.0 Safari/537.36"
+                )
+            }
+        )
+
+        for char in "abcdefghijklmnopqrstuvwxyz":
+            url = f"http://ufcstats.com/statistics/fighters?char={char}&page=all"
+            soup = fetch_soup(session, url, timeout=timeout)
+            if not soup:
                 continue
-            profile_url = link["href"]
-            profile_soup = fetch_soup(profile_url, timeout=timeout)
-            if not profile_soup:
+            table = soup.select_one("table")
+            if not table:
                 continue
-            full_name_tag = profile_soup.select_one("span.b-content__title-highlight")
-            birthdate_tag = profile_soup.select_one(
-                ".b-list__info-box_style_small-width li:nth-of-type(5)"
-            )
-            full_names.append(full_name_tag.text.strip() if full_name_tag else "N/A")
-            birthdates.append(birthdate_tag.text.strip() if birthdate_tag else "N/A")
-            heights.append(cols[3].text.strip())
-            weights.append(cols[4].text.strip())
-            reaches.append(cols[5].text.strip())
-            stances.append(cols[6].text.strip())
-            wins.append(cols[7].text.strip())
-            losses.append(cols[8].text.strip())
-            draws.append(cols[9].text.strip())
-            time.sleep(delay)  # be polite with the server
+            for row in table.select("tr:nth-of-type(n+2)"):
+                cols = row.find_all("td")
+                link = cols[1].find("a")
+                if not link:
+                    continue
+                profile_url = link["href"]
+                profile_soup = fetch_soup(session, profile_url, timeout=timeout)
+                if not profile_soup:
+                    continue
+                full_name_tag = profile_soup.select_one("span.b-content__title-highlight")
+                birthdate_tag = profile_soup.select_one(
+                    ".b-list__info-box_style_small-width li:nth-of-type(5)"
+                )
+                full_names.append(full_name_tag.text.strip() if full_name_tag else "N/A")
+                birthdates.append(birthdate_tag.text.strip() if birthdate_tag else "N/A")
+                heights.append(cols[3].text.strip())
+                weights.append(cols[4].text.strip())
+                reaches.append(cols[5].text.strip())
+                stances.append(cols[6].text.strip())
+                wins.append(cols[7].text.strip())
+                losses.append(cols[8].text.strip())
+                draws.append(cols[9].text.strip())
+                time.sleep(delay)  # be polite with the server
 
     return pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- Pass a requests.Session instance to `fetch` and `fetch_soup` to avoid relying on a global session
- Manage the HTTP session within `scrape_fighters` using a `with` block to ensure connections close

## Testing
- `python -m py_compile scraping.py`
- `pytest`
- `python - <<'PY'
import scraping
from unittest.mock import patch, MagicMock

class DummySession:
    def __init__(self):
        self.headers = {}
        self.get = MagicMock(return_value=MagicMock(status_code=404))
        self.close = MagicMock()
    def __enter__(self):
        return self
    def __exit__(self, exc_type, exc, tb):
        self.close()

session_instance = DummySession()

def session_factory():
    return session_instance

with patch('requests.Session', session_factory):
    scraping.scrape_fighters()

print('session closed:', session_instance.close.called)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689bbdd236648324a2380c2ff621e99e