### PR TITLE
Handle zero totals during probability normalization

### DIFF
--- a/app.py
+++ b/app.py
@@ -121,15 +121,18 @@ else:
         proba_fighter_1 = pred_proba_fighter_1[0][1]  # Probabilidad de que fighter_1 gane
         proba_fighter_2 = pred_proba_fighter_2[0][1]  # Probabilidad de que fighter_2 gane
 
-        # Normalizar las probabilidades para que sumen 100%
+        # Normalizar las probabilidades para que sumen 100% solo si el total es mayor a 0
         total = proba_fighter_1 + proba_fighter_2
-        proba_fighter_1_normalized = (proba_fighter_1 / total) * 100
-        proba_fighter_2_normalized = (proba_fighter_2 / total) * 100
+        if total > 0:
+            proba_fighter_1_normalized = (proba_fighter_1 / total) * 100
+            proba_fighter_2_normalized = (proba_fighter_2 / total) * 100
 
-        st.write("\n--- Resultados de la Predicción del Ganador ---")
-        st.write(f"{fighter_1}: {proba_fighter_1_normalized:.2f}%")
-        st.write(f"{fighter_2}: {proba_fighter_2_normalized:.2f}%")
-        st.write(f"Predicción del ganador: {fighter_1 if proba_fighter_1_normalized > proba_fighter_2_normalized else fighter_2}")
+            st.write("\n--- Resultados de la Predicción del Ganador ---")
+            st.write(f"{fighter_1}: {proba_fighter_1_normalized:.2f}%")
+            st.write(f"{fighter_2}: {proba_fighter_2_normalized:.2f}%")
+            st.write(f"Predicción del ganador: {fighter_1 if proba_fighter_1_normalized > proba_fighter_2_normalized else fighter_2}")
+        else:
+            st.error("Error: la suma de probabilidades es 0, se omite la normalización.")
 
     # Función para hacer la predicción del método de pelea
     def hacer_prediccion_method(stacking_method, stats_fighter_1, stats_fighter_2):


### PR DESCRIPTION
## Summary
- Avoid dividing by zero when normalizing prediction probabilities
- Display an error message when total probability equals zero and skip normalization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689bc2d98d8883249c4f995f45855f2d