### PR TITLE
Remove pymysql from core requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,15 @@ La aplicación Streamlit está disponible públicamente en el siguiente enlace:
    source env/bin/activate  # en Linux/macOS
    env\Scripts\activate   # en Windows
    ```
-3. Instala las dependencias:
+3. Instala las dependencias principales:
    ```bash
    pip install -r requirements.txt
    ```
-4. Corre la aplicación Streamlit:
+4. (Opcional) Instala dependencias de desarrollo como `pymysql` para `upload_to_sql.py`:
+   ```bash
+   pip install -r dev-requirements.txt
+   ```
+5. Corre la aplicación Streamlit:
    ```bash
    streamlit run app.py
    ```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ scipy==1.14.1
 tensorflow==2.17.0
 openpyxl==3.1.5
 pytest
+pymysql==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ lightgbm==4.5.0
 beautifulsoup4==4.12.0
 requests>=2.32.0
 joblib==1.4.2
-pymysql==1.1.0


### PR DESCRIPTION
## Summary
- drop `pymysql` from `requirements.txt`
- add `pymysql` to `dev-requirements.txt` and document optional install in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc5aa32688324ac296d7b7db76806