### PR TITLE
refactor: simplify dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ La aplicación Streamlit está disponible públicamente en el siguiente enlace:
    streamlit run app.py
    ```
 
+### Dependencias opcionales para análisis
+
+Algunas librerías se utilizan solo para análisis puntuales y no se instalan por defecto. Instálalas manualmente si las necesitas:
+
+- matplotlib
+- selenium
+- webdriver-manager
+- scipy
+- tensorflow
+- openpyxl
+
 ## 🏋️ Entrenamiento de modelos
 
 Los modelos se entrenan mediante scripts ubicados en la raíz del proyecto.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,1 @@
-matplotlib==3.7.1
-selenium==4.10.0
-webdriver-manager==3.8.6
-scipy==1.14.1
-tensorflow==2.17.0
-openpyxl==3.1.5
 pytest


### PR DESCRIPTION
## Summary
- trim unused dev dependencies down to pytest only
- note optional analysis libraries in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc5b9b1f0832493b20d02b050ab8f