### PR TITLE
Simplify workflow debug listing

### DIFF
--- a/.github/workflows/entrenamiento_dependiente.yml
+++ b/.github/workflows/entrenamiento_dependiente.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: '3.10'
 
     - name: Mostrar estructura (debug)
-      run: ls -R
+      run: ls
 
     - name: Instalar dependencias
       run: pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- avoid recursive file listing in entrenamiento_dependiente workflow to reduce delay

## Testing
- `pip install -r dev-requirements.txt` (fails: Could not find a version that satisfies the requirement pymysql==1.1.0 due to proxy 403)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c105097b883248ec34c8e9084aa4d