### PR TITLE
Run winner training in workflow

### DIFF
--- a/.github/workflows/entrenamiento_dependiente.yml
+++ b/.github/workflows/entrenamiento_dependiente.yml
@@ -29,6 +29,9 @@ jobs:
     - name: Entrenar modelos
       run: python entrenamiento.py
 
+    - name: Entrenar modelo Winner
+      run: python entrenamiento_winner.py
+
     - name: Guardar modelos
       uses: EndBug/add-and-commit@v9
       with:


### PR DESCRIPTION
## Summary
- run winner training script after method training in dependent workflow

## Testing
- `python entrenamiento.py` (modified locally for verification)
- `python entrenamiento_winner.py` (modified locally for verification)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c189abd3083248ee4a3c21a9f7b6d