### PR TITLE
Add computation of last five fight stats

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -1,0 +1,50 @@
+"""Utility functions for fight statistics analysis."""
+from __future__ import annotations
+
+import pandas as pd
+
+
+MIN_COLUMNS = {"fighter", "date"}
+
+
+def compute_last_five_stats(df_fights: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate statistics for each fighter's last five fights.
+
+    Parameters
+    ----------
+    df_fights:
+        DataFrame containing fight level statistics. It must include at
+        least the columns in :data:`MIN_COLUMNS`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with one row per fighter containing the mean of the
+        numeric statistics for the fighter's last five bouts. The ``date``
+        column corresponds to the most recent fight considered.
+
+    Raises
+    ------
+    ValueError
+        If any of the required columns are missing from ``df_fights``.
+    """
+
+    missing = MIN_COLUMNS - set(df_fights.columns)
+    if missing:
+        raise ValueError(f"df_fights is missing required columns: {missing}")
+
+    df = df_fights.copy()
+    df["date"] = pd.to_datetime(df["date"])
+    df.sort_values("date", inplace=True)
+
+    last_five = df.groupby("fighter").tail(5)
+
+    def _aggregate(group: pd.DataFrame) -> pd.Series:
+        numeric = group.select_dtypes(include="number").mean()
+        numeric["fighter"] = group["fighter"].iloc[0]
+        numeric["date"] = group["date"].max()
+        return numeric
+
+    result = last_five.groupby("fighter", as_index=False).apply(_aggregate)
+    result.reset_index(drop=True, inplace=True)
+    return result

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from analysis import compute_last_five_stats
+
+
+def test_compute_last_five_stats_missing_columns():
+    df = pd.DataFrame({"fighter": ["A"]})
+    with pytest.raises(ValueError):
+        compute_last_five_stats(df)
+
+
+def test_compute_last_five_stats_tail_and_date_conversion():
+    df = pd.DataFrame(
+        {
+            "fighter": ["A"] * 6,
+            "date": pd.date_range("2020-01-01", periods=6, freq="D").astype(str),
+            "KD": range(6),
+        }
+    )
+
+    result = compute_last_five_stats(df)
+
+    assert pd.api.types.is_datetime64_any_dtype(result["date"])
+    assert result.loc[result["fighter"] == "A", "KD"].iloc[0] == pytest.approx(3.0)
+    assert result.loc[result["fighter"] == "A", "date"].iloc[0] == pd.Timestamp("2020-01-06")


### PR DESCRIPTION
## Summary
- add `analysis.py` with `compute_last_five_stats` to aggregate last five bouts per fighter
- ensure required columns exist and convert dates to datetime
- test aggregation, column validation, and date conversion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d557c68c0832483455ffb94eec9ec