### PR TITLE
feat: add sequential fight numbering

### DIFF
--- a/preprocessing.py
+++ b/preprocessing.py
@@ -1,4 +1,4 @@
-"""Data cleaning and preprocessing utilities for UFC fighters."""
+"""Data cleaning and preprocessing utilities for UFC fighters and fights."""
 from __future__ import annotations
 import re
 import pandas as pd
@@ -84,3 +84,21 @@ def preprocess_fighters(df: pd.DataFrame) -> pd.DataFrame:
             "birthdate",
         ]
     ]
+
+
+def add_fight_number(df_fights: pd.DataFrame) -> pd.DataFrame:
+    """Sort fights by fighter and date and assign sequential numbers.
+
+    Parameters
+    ----------
+    df_fights:
+        DataFrame containing at least ``fighter_name`` and ``date`` columns.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The sorted DataFrame with a new ``fight_number`` column.
+    """
+    df_fights = df_fights.sort_values(["fighter_name", "date"])
+    df_fights["fight_number"] = df_fights.groupby("fighter_name").cumcount() + 1
+    return df_fights

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,10 +1,15 @@
 import os
 import sys
-
+import pandas as pd
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from preprocessing import convert_height_to_cm, convert_weight_to_kg, convert_reach_to_cm
+from preprocessing import (
+    convert_height_to_cm,
+    convert_weight_to_kg,
+    convert_reach_to_cm,
+    add_fight_number,
+)
 
 
 def test_convert_height_to_cm_malformed():
@@ -23,3 +28,27 @@ def test_convert_reach_to_cm_malformed():
     assert convert_reach_to_cm("--") is None
     assert convert_reach_to_cm("") is None
     assert convert_reach_to_cm("bad format") is None
+
+
+def test_add_fight_number():
+    df = pd.DataFrame(
+        {
+            "fighter_name": ["A", "A", "B", "A"],
+            "date": pd.to_datetime(
+                ["2021-01-01", "2021-06-01", "2020-01-01", "2020-01-01"]
+            ),
+        }
+    )
+
+    result = add_fight_number(df)
+    expected = pd.DataFrame(
+        {
+            "fighter_name": ["A", "A", "A", "B"],
+            "date": pd.to_datetime(
+                ["2020-01-01", "2021-01-01", "2021-06-01", "2020-01-01"]
+            ),
+            "fight_number": [1, 2, 3, 1],
+        }
+    )
+
+    pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)


### PR DESCRIPTION
## Summary
- add `add_fight_number` helper to sort fights and compute a per-fighter fight_number
- test fight numbering logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d557d369c8324b4decbc4d0f9f1bf