### PR TITLE
Add rolling averages and form calculation for fighters

### DIFF
--- a/preprocessing.py
+++ b/preprocessing.py
@@ -1,4 +1,4 @@
-"""Data cleaning and preprocessing utilities for UFC fighters."""
+"""Data cleaning and preprocessing utilities for UFC data."""
 from __future__ import annotations
 import re
 import pandas as pd
@@ -84,3 +84,41 @@ def preprocess_fighters(df: pd.DataFrame) -> pd.DataFrame:
             "birthdate",
         ]
     ]
+
+
+def add_rolling_features(df_fights: pd.DataFrame) -> pd.DataFrame:
+    """Compute rolling five-fight averages and form for each fighter.
+
+    Parameters
+    ----------
+    df_fights:
+        DataFrame containing per-fight statistics. It must include the
+        columns ``fighter_name`` and ``result`` in addition to numeric
+        columns such as ``KD``, ``Sig Str``, ``TD`` and ``Control``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        ``df_fights`` enriched with the rolling means for the selected
+        numeric columns and a ``form_last_5`` column indicating the
+        average win ratio over the last five fights for each fighter.
+    """
+
+    cols = [c for c in ["KD", "Sig Str", "TD", "Control"] if c in df_fights.columns]
+    rolling = (
+        df_fights.groupby("fighter_name")[cols]
+        .rolling(5, min_periods=1)
+        .mean()
+        .reset_index(level=0, drop=True)
+    )
+    df_fights[cols] = rolling
+
+    wins = (df_fights["result"] == "W").astype(int)
+    df_fights["form_last_5"] = (
+        wins.groupby(df_fights["fighter_name"])  # type: ignore[arg-type]
+        .rolling(5, min_periods=1)
+        .mean()
+        .reset_index(level=0, drop=True)
+    )
+
+    return df_fights

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -4,7 +4,13 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from preprocessing import convert_height_to_cm, convert_weight_to_kg, convert_reach_to_cm
+from preprocessing import (
+    convert_height_to_cm,
+    convert_weight_to_kg,
+    convert_reach_to_cm,
+    add_rolling_features,
+)
+import pandas as pd
 
 
 def test_convert_height_to_cm_malformed():
@@ -23,3 +29,23 @@ def test_convert_reach_to_cm_malformed():
     assert convert_reach_to_cm("--") is None
     assert convert_reach_to_cm("") is None
     assert convert_reach_to_cm("bad format") is None
+
+
+def test_add_rolling_features():
+    df = pd.DataFrame(
+        {
+            "fighter_name": ["A", "A", "A", "B", "A", "B"],
+            "KD": [0, 1, 2, 0, 3, 1],
+            "Sig Str": [10, 20, 30, 5, 40, 15],
+            "TD": [0, 1, 0, 0, 2, 0],
+            "Control": [0, 50, 100, 0, 150, 0],
+            "result": ["W", "L", "W", "W", "L", "L"],
+        }
+    )
+    res = add_rolling_features(df)
+    assert res.loc[0, "KD"] == 0
+    assert res.loc[1, "KD"] == pytest.approx(0.5)
+    assert res.loc[2, "KD"] == pytest.approx(1.0)
+    assert res.loc[4, "KD"] == pytest.approx(1.5)
+    assert res.loc[3, "form_last_5"] == 1.0
+    assert res.loc[5, "form_last_5"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- add utility to compute rolling means over fighters' last five bouts and win form
- expand preprocessing tests to cover rolling feature generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d557f69e08324b0d13ff1f99ae39e