### PR TITLE
Add last five fight stats computation and tests

### DIFF
--- a/preprocessing.py
+++ b/preprocessing.py
@@ -84,3 +84,38 @@ def preprocess_fighters(df: pd.DataFrame) -> pd.DataFrame:
             "birthdate",
         ]
     ]
+
+def compute_last_five_stats(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute rolling averages for the previous five fights of each fighter.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing at least ``Fighter``, ``Result`` and numeric
+        statistics (e.g. ``KD``, ``TD``).
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame where numeric columns represent the average of the previous
+        five fights and includes a ``form_last_5`` column with the win ratio in
+        the same window. The original ``Result`` column is dropped in the
+        returned DataFrame.
+    """
+    df = df.copy()
+    if "Fighter" not in df.columns or "Result" not in df.columns:
+        raise ValueError("DataFrame must contain 'Fighter' and 'Result' columns")
+
+    # Map results to numeric wins (1) and losses (0)
+    df["_win"] = df["Result"].map({"W": 1, "L": 0}).fillna(df["Result"])
+
+    numeric_cols = df.select_dtypes(include="number").columns.difference(["_win"])
+    grouped = df.groupby("Fighter")
+
+    # Proportion of wins in the previous five fights
+    df["form_last_5"] = grouped["_win"].transform(lambda s: s.shift().rolling(5, min_periods=1).mean())
+
+    for col in numeric_cols:
+        df[col] = grouped[col].transform(lambda s: s.shift().rolling(5, min_periods=1).mean())
+
+    return df.drop(columns=["Result", "_win"])

--- a/tests/test_last_five_stats.py
+++ b/tests/test_last_five_stats.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from preprocessing import compute_last_five_stats
+
+
+def test_compute_last_five_stats_form_and_means():
+    data = {
+        "Fighter": ["Test Fighter"] * 6,
+        "Result": ["W", "L", "W", "L", "W", "L"],
+        "KD": [1, 2, 3, 4, 5, 6],
+        "TD": [6, 5, 4, 3, 2, 1],
+    }
+    df = pd.DataFrame(data)
+    stats = compute_last_five_stats(df)
+
+    sixth_fight = stats.iloc[5]
+    assert sixth_fight["form_last_5"] == pytest.approx(0.6)
+    assert sixth_fight["KD"] == pytest.approx(3.0)
+    assert sixth_fight["TD"] == pytest.approx(4.0)


### PR DESCRIPTION
## Summary
- Add `compute_last_five_stats` to calculate rolling averages and form over the previous five fights
- Add unit test verifying correct computation of last five fight stats

## Testing
- `pytest tests/test_last_five_stats.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d55857910832480f22653a331db77