### PR TITLE
Fix preprocessing test import

### DIFF
--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -8,8 +8,8 @@ from preprocessing import (
     convert_height_to_cm,
     convert_weight_to_kg,
     convert_reach_to_cm,
-
-
+    preprocess_fighters,
+)
 
 def test_convert_height_to_cm_malformed():
     assert convert_height_to_cm("--") is None


### PR DESCRIPTION
## Summary
- complete import list in preprocessing tests and close statement

## Testing
- `pytest` *(fails: invalid syntax in preprocessing.py)*

------
https://chatgpt.com/codex/tasks/task_e_689d60488a408324bd33d42cc4f2b075