### PR TITLE
Handle missing training data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Algunas librerías se utilizan solo para análisis puntuales y no se instalan po
 Los modelos se entrenan mediante scripts ubicados en la raíz del proyecto.
 Los artefactos generados se guardan en `models/{MODEL_VERSION}/`.
 
+Antes de ejecutar estos scripts, asegúrate de que el archivo `data/fight_stats.csv` exista,
+ya que contiene las características utilizadas para el entrenamiento.
+
 Para entrenar el modelo del método de victoria:
 
 ```bash

--- a/train_model.py
+++ b/train_model.py
@@ -27,12 +27,21 @@ DATA_DIR = os.path.abspath("data")
 MODELS_DIR = os.path.abspath(os.path.join("models", MODEL_VERSION))
 os.makedirs(MODELS_DIR, exist_ok=True)
 
-fight_stats = pd.read_csv(os.path.join(DATA_DIR, "fight_stats.csv"))
-columnas_X = (
-    pd.read_csv(os.path.join(DATA_DIR, "columnas_X.csv"), header=None)
-    .squeeze()
-    .tolist()
-)
+try:
+    fight_stats = pd.read_csv(os.path.join(DATA_DIR, "fight_stats.csv"))
+except FileNotFoundError:
+    print("❌ No se encontró 'data/fight_stats.csv'. Genera este archivo antes de entrenar.")
+    raise SystemExit(1)
+
+try:
+    columnas_X = (
+        pd.read_csv(os.path.join(DATA_DIR, "columnas_X.csv"), header=None)
+        .squeeze()
+        .tolist()
+    )
+except FileNotFoundError:
+    print("❌ No se encontró 'data/columnas_X.csv'. Asegúrate de crear este archivo.")
+    raise SystemExit(1)
 
 X = fight_stats[columnas_X]
 


### PR DESCRIPTION
## Summary
- Guard against missing `fight_stats.csv` and `columnas_X.csv` when training models
- Document training requirement for `fight_stats.csv`

## Testing
- `pytest -q` *(fails: SyntaxError in tests/test_preprocessing.py)*

------
https://chatgpt.com/codex/tasks/task_e_689d604d41ac8324bdd8905fb1a6561c