### PR TITLE
Rename aggregation utility and clarify rolling dataset docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,12 @@ Para entrenar el modelo del ganador del combate:
 python entrenamiento_winner.py
 ```
 
+## 📊 Agregación vs Dataset Rolling
+
+- `analysis.aggregate_last_five_stats`: produce un único registro por
+  peleador calculando la media de las estadísticas de sus últimas cinco
+  peleas.
+- `fight_stats.compute_last_five_stats`: genera un dataset con una fila por
+  combate e incluye medias móviles y la racha de victorias de los últimos
+  cinco enfrentamientos.
+

--- a/analysis.py
+++ b/analysis.py
@@ -7,8 +7,12 @@ import pandas as pd
 MIN_COLUMNS = {"fighter", "date"}
 
 
-def compute_last_five_stats(df_fights: pd.DataFrame) -> pd.DataFrame:
+def aggregate_last_five_stats(df_fights: pd.DataFrame) -> pd.DataFrame:
     """Aggregate statistics for each fighter's last five fights.
+
+    Unlike :func:`fight_stats.compute_last_five_stats`, which returns a row per
+    bout with rolling averages, this utility collapses the last five bouts of
+    each fighter into a single aggregated record.
 
     Parameters
     ----------

--- a/fight_stats.py
+++ b/fight_stats.py
@@ -28,12 +28,12 @@ def _time_to_seconds(text: str) -> int:
 
 
 def compute_last_five_stats(csv_path: str | Path = DATA_DIR / "fight_stats_raw.csv") -> pd.DataFrame:
-    """Compute rolling statistics for the last five fights of each fighter.
+    """Generate a rolling dataset for the last five fights of each fighter.
 
-    The function expects the raw fight statistics CSV produced by the scraping
-    utilities.  It parses numeric values, computes per-fighter rolling means for
-    several statistics and a ``form_last_5`` column indicating the number of
-    wins in the last five fights.
+    This routine keeps one row per bout and appends rolling averages for
+    numerous statistics as well as a ``form_last_5`` column with the number of
+    recent wins. For a per-fighter aggregated summary, see
+    :func:`analysis.aggregate_last_five_stats`.
     """
     df = pd.read_csv(csv_path)
 

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -84,15 +84,3 @@ def preprocess_fighters(df: pd.DataFrame) -> pd.DataFrame:
             "birthdate",
         ]
     ]
-
-
-    Parameters
-    ----------
-    df_fights:
-
-
-    Returns
-    -------
-    pandas.DataFrame
-
-    return df_fights

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -5,16 +5,16 @@ import pandas as pd
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from analysis import compute_last_five_stats
+from analysis import aggregate_last_five_stats
 
 
-def test_compute_last_five_stats_missing_columns():
+def test_aggregate_last_five_stats_missing_columns():
     df = pd.DataFrame({"fighter": ["A"]})
     with pytest.raises(ValueError):
-        compute_last_five_stats(df)
+        aggregate_last_five_stats(df)
 
 
-def test_compute_last_five_stats_tail_and_date_conversion():
+def test_aggregate_last_five_stats_tail_and_date_conversion():
     df = pd.DataFrame(
         {
             "fighter": ["A"] * 6,
@@ -23,7 +23,7 @@ def test_compute_last_five_stats_tail_and_date_conversion():
         }
     )
 
-    result = compute_last_five_stats(df)
+    result = aggregate_last_five_stats(df)
 
     assert pd.api.types.is_datetime64_any_dtype(result["date"])
     assert result.loc[result["fighter"] == "A", "KD"].iloc[0] == pytest.approx(3.0)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -8,7 +8,7 @@ from preprocessing import (
     convert_height_to_cm,
     convert_weight_to_kg,
     convert_reach_to_cm,
-
+)
 
 
 def test_convert_height_to_cm_malformed():
@@ -27,5 +27,4 @@ def test_convert_reach_to_cm_malformed():
     assert convert_reach_to_cm("--") is None
     assert convert_reach_to_cm("") is None
     assert convert_reach_to_cm("bad format") is None
-
 


### PR DESCRIPTION
## Summary
- rename `compute_last_five_stats` to `aggregate_last_five_stats`
- document difference between per-fighter aggregation and rolling dataset generation
- fix preprocessing test and module syntax so tests run

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d605000b083248cf9a9631d6fa20c