### PR TITLE
Fix missing parenthesis in preprocessing test import

### DIFF
--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -8,6 +8,7 @@ from preprocessing import (
     convert_height_to_cm,
     convert_weight_to_kg,
     convert_reach_to_cm,
+)
 
 def test_convert_height_to_cm_malformed():
     assert convert_height_to_cm("--") is None


### PR DESCRIPTION
## Summary
- Close the `from preprocessing import` block in tests/test_preprocessing.py with a parenthesis.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d6ad77160832484c64e4d0057852a