### PR TITLE
Remove debug step from training workflow

### DIFF
--- a/.github/workflows/entrenamiento_dependiente.yml
+++ b/.github/workflows/entrenamiento_dependiente.yml
@@ -20,9 +20,6 @@ jobs:
       with:
         python-version: '3.10'
 
-    - name: Mostrar estructura (debug)
-      run: ls
-
     - name: Instalar dependencias
       run: pip install -r requirements.txt
 


### PR DESCRIPTION
## Summary
- remove `Mostrar estructura (debug)` step from `entrenamiento_dependiente` workflow

## Testing
- `pytest`
- `actionlint .github/workflows/entrenamiento_dependiente.yml` *(fails: command not found; install attempts blocked by network policy)*
- `yamllint .github/workflows/entrenamiento_dependiente.yml` *(fails: command not found; install attempts blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_689d6da5214c83248381f6bac07b7ecb