### PR TITLE
Handle non-string birthdates in preprocessing

### DIFF
--- a/preprocessing.py
+++ b/preprocessing.py
@@ -64,11 +64,15 @@ def preprocess_fighters(df: pd.DataFrame) -> pd.DataFrame:
     df["weight_kg"].fillna(0, inplace=True)
     df["reach_cm"].fillna(0, inplace=True)
 
-    df["birthdate"] = df["birthdate"].apply(
-        lambda x: re.search(r"\w{3} \d{2}, \d{4}", x).group(0)
-        if re.search(r"\w{3} \d{2}, \d{4}", x)
-        else "N/A"
-    )
+    def _extract_birthdate(x: object) -> str:
+        """Extract a normalized birthdate string if possible."""
+        if isinstance(x, str):
+            match = re.search(r"\w{3} \d{2}, \d{4}", str(x))
+            if match:
+                return match.group(0)
+        return "N/A"
+
+    df["birthdate"] = df["birthdate"].apply(_extract_birthdate)
 
     return df[
         [

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -8,6 +8,7 @@ from preprocessing import (
     convert_height_to_cm,
     convert_weight_to_kg,
     convert_reach_to_cm,
+    preprocess_fighters,
 )
 
 def test_convert_height_to_cm_malformed():
@@ -26,4 +27,32 @@ def test_convert_reach_to_cm_malformed():
     assert convert_reach_to_cm("--") is None
     assert convert_reach_to_cm("") is None
     assert convert_reach_to_cm("bad format") is None
+
+
+def _make_df(birthdate):
+    return pd.DataFrame(
+        {
+            "full_name": ["Test Fighter"],
+            "height": [None],
+            "weight": [None],
+            "reach": [None],
+            "stance": ["Orthodox"],
+            "wins": [0],
+            "losses": [0],
+            "draws": [0],
+            "birthdate": [birthdate],
+        }
+    )
+
+
+def test_preprocess_fighters_birthdate_nan():
+    df = _make_df(float("nan"))
+    result = preprocess_fighters(df)
+    assert result.loc[0, "birthdate"] == "N/A"
+
+
+def test_preprocess_fighters_birthdate_none():
+    df = _make_df(None)
+    result = preprocess_fighters(df)
+    assert result.loc[0, "birthdate"] == "N/A"
 


### PR DESCRIPTION
## Summary
- Guard `preprocess_fighters` birthdate parsing against non-string values
- Normalize birthdate values to `N/A` when `None` or `NaN`
- Add tests covering `NaN` and `None` birthdate cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e939a59048324bf1e205039c3a196