### PR TITLE
Use train_test_split for model training and ensure deterministic split

### DIFF
--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -1,0 +1,78 @@
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import train_model  # noqa: E402
+
+
+class DummyGridSearchCV:
+    """Lightweight replacement for GridSearchCV used in tests."""
+
+    def __init__(self, estimator, *args, **kwargs):
+        self.best_estimator_ = estimator
+        self.best_params_ = {}
+
+    def fit(self, X, y):  # pragma: no cover - trivial
+        self.best_estimator_.fit(X, y)
+        return self
+
+
+class DummyStackingClassifier:
+    """Simplified stacking classifier for fast deterministic tests."""
+
+    def __init__(self, *args, **kwargs):
+        self.classes_ = None
+
+    def fit(self, X, y):  # pragma: no cover - trivial
+        self.classes_ = np.unique(y)
+        return self
+
+    def predict(self, X):  # pragma: no cover - trivial
+        return np.repeat(self.classes_[0], len(X))
+
+    def predict_proba(self, X):  # pragma: no cover - trivial
+        proba = np.zeros((len(X), len(self.classes_)))
+        proba[:, 0] = 1.0
+        return proba
+
+
+def test_train_split_deterministic(tmp_path, monkeypatch):
+    X = pd.DataFrame({"feat": range(12)})
+    y = [0, 1] * 6
+
+    train_model.X = X
+    train_model.fight_stats = X.assign(Winner=y)
+    train_model.models = {
+        "LogReg": (LogisticRegression(random_state=train_model.RANDOM_STATE), {})
+    }
+    train_model.MODELS_DIR = tmp_path
+
+    monkeypatch.setattr(train_model.joblib, "dump", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_model, "GridSearchCV", DummyGridSearchCV)
+    monkeypatch.setattr(train_model, "StackingClassifier", DummyStackingClassifier)
+
+    splits = []
+    real_tts = train_model.train_test_split
+
+    def record_split(*args, **kwargs):
+        result = real_tts(*args, **kwargs)
+        splits.append(result)
+        return result
+
+    monkeypatch.setattr(train_model, "train_test_split", record_split)
+
+    train_model.train("Winner")
+    train_model.train("Winner")
+
+    (X_train1, X_test1, y_train1, y_test1), (X_train2, X_test2, y_train2, y_test2) = splits
+
+    pd.testing.assert_frame_equal(X_train1, X_train2)
+    pd.testing.assert_frame_equal(X_test1, X_test2)
+    pd.testing.assert_series_equal(y_train1, y_train2)
+    pd.testing.assert_series_equal(y_test1, y_test2)
+

--- a/train_model.py
+++ b/train_model.py
@@ -14,7 +14,7 @@ import pandas as pd
 from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier, StackingClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score, roc_auc_score
-from sklearn.model_selection import GridSearchCV, StratifiedKFold
+from sklearn.model_selection import GridSearchCV, StratifiedKFold, train_test_split
 from sklearn.svm import SVC
 from lightgbm import LGBMClassifier
 from xgboost import XGBClassifier
@@ -103,9 +103,9 @@ def train(target_column: str) -> None:
     """
 
     y = fight_stats[target_column]
-    split = int(len(X) * 0.8)
-    X_train, X_test = X.iloc[:split], X.iloc[split:]
-    y_train, y_test = y.iloc[:split], y.iloc[split:]
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=RANDOM_STATE
+    )
 
     cv = StratifiedKFold(n_splits=3, shuffle=True, random_state=RANDOM_STATE)
     mejores = []


### PR DESCRIPTION
## Summary
- Replace manual data slicing in `train_model.train` with `train_test_split` using a fixed `RANDOM_STATE`.
- Add regression test to guarantee deterministic train/test splits.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e939da8708324ab4acc632b7f09f7