### PR TITLE
Centralize model version config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Algunas librerías se utilizan solo para análisis puntuales y no se instalan po
 ## 🏋️ Entrenamiento de modelos
 
 Los modelos se entrenan mediante scripts ubicados en la raíz del proyecto.
-Los artefactos generados se guardan en `models/{MODEL_VERSION}/`.
+Los artefactos generados se guardan en `models/{MODEL_VERSION}/`, donde la
+versión se centraliza en `ufc_predictor/config.py`.
 
 Antes de ejecutar estos scripts, asegúrate de que el archivo `data/fight_stats.csv` exista,
 ya que contiene las características utilizadas para el entrenamiento.

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import streamlit as st
 import joblib
 import pandas as pd
 
-MODEL_VERSION = "1.0"  # Versión del modelo utilizada para construir las rutas
+from ufc_predictor.config import MODEL_VERSION
 
 
 @st.cache_resource(show_spinner="Cargando modelo del ganador...")

--- a/train_model.py
+++ b/train_model.py
@@ -9,6 +9,7 @@ models and their evaluation metrics under ``models/{MODEL_VERSION}``.
 """
 
 import os
+
 import joblib
 import pandas as pd
 from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier, StackingClassifier
@@ -20,8 +21,9 @@ from lightgbm import LGBMClassifier
 from xgboost import XGBClassifier
 from catboost import CatBoostClassifier
 
+from ufc_predictor.config import MODEL_VERSION
+
 RANDOM_STATE = 42
-MODEL_VERSION = "1.0"
 
 DATA_DIR = os.path.abspath("data")
 MODELS_DIR = os.path.abspath(os.path.join("models", MODEL_VERSION))

--- a/ufc_predictor/__init__.py
+++ b/ufc_predictor/__init__.py
@@ -1,0 +1,5 @@
+"""UFC Predictor package."""
+
+from .config import MODEL_VERSION
+
+__all__ = ["MODEL_VERSION"]

--- a/ufc_predictor/config.py
+++ b/ufc_predictor/config.py
@@ -1,0 +1,3 @@
+"""Project configuration constants."""
+
+MODEL_VERSION = "1.0"


### PR DESCRIPTION
## Summary
- add `ufc_predictor.config` with a single `MODEL_VERSION` constant
- import `MODEL_VERSION` from `ufc_predictor` in training and application scripts
- document centralized model version in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e93a72dc08324a9c1f72caab72328