### PR TITLE
Handle null birthdates in preprocess_fighters

### DIFF
--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -5,6 +5,7 @@ from ufc_predictor.preprocessing import (
     convert_height_to_cm,
     convert_weight_to_kg,
     convert_reach_to_cm,
+    preprocess_fighters,
 )
 
 def test_convert_height_to_cm_malformed():
@@ -23,4 +24,25 @@ def test_convert_reach_to_cm_malformed():
     assert convert_reach_to_cm("--") is None
     assert convert_reach_to_cm("") is None
     assert convert_reach_to_cm("bad format") is None
+
+
+def test_preprocess_fighters_birthdate_null_values():
+    df = pd.DataFrame(
+        {
+            "full_name": ["F1", "F2"],
+            "height": ["6' 0\"", "5' 8\""],
+            "weight": ["170 lbs.", "145 lbs."],
+            "reach": ["70\"", "68\""],
+            "stance": ["Orthodox", "Southpaw"],
+            "wins": [10, 5],
+            "losses": [2, 3],
+            "draws": [0, 1],
+            "birthdate": [None, float("nan")],
+        }
+    )
+
+    processed = preprocess_fighters(df)
+
+    assert (processed.loc[processed["full_name"] == "F1", "birthdate"].item()) == "N/A"
+    assert (processed.loc[processed["full_name"] == "F2", "birthdate"].item()) == "N/A"
 

--- a/ufc_predictor/preprocessing.py
+++ b/ufc_predictor/preprocessing.py
@@ -65,9 +65,12 @@ def preprocess_fighters(df: pd.DataFrame) -> pd.DataFrame:
     df["reach_cm"].fillna(0, inplace=True)
 
     df["birthdate"] = df["birthdate"].apply(
-        lambda x: re.search(r"\w{3} \d{2}, \d{4}", x).group(0)
-        if re.search(r"\w{3} \d{2}, \d{4}", x)
-        else "N/A"
+        lambda x: (
+            re.search(r"\w{3} \d{2}, \d{4}", str(x)).group(0)
+            if pd.notnull(x)
+            and re.search(r"\w{3} \d{2}, \d{4}", str(x))
+            else "N/A"
+        )
     )
 
     return df[


### PR DESCRIPTION
## Summary
- Safely parse fighter birthdates by converting to string and checking for nulls before applying regex
- Add unit tests ensuring `preprocess_fighters` handles `None` and `NaN` birthdates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e9ab7f380832499b9d0a674f160c9