### PR TITLE
Handle missing fight stats CSV

### DIFF
--- a/tests/test_fight_stats.py
+++ b/tests/test_fight_stats.py
@@ -1,0 +1,12 @@
+import pandas as pd
+
+from ufc_predictor.fight_stats import compute_last_five_stats
+
+
+def test_compute_last_five_stats_missing_csv(tmp_path, capsys):
+    missing_file = tmp_path / "missing.csv"
+    df = compute_last_five_stats(missing_file)
+    captured = capsys.readouterr()
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
+    assert "not found" in captured.out.lower()

--- a/ufc_predictor/fight_stats.py
+++ b/ufc_predictor/fight_stats.py
@@ -34,8 +34,15 @@ def compute_last_five_stats(csv_path: str | Path = DATA_DIR / "fight_stats_raw.c
     numerous statistics as well as a ``form_last_5`` column with the number of
     recent wins. For a per-fighter aggregated summary, see
     :func:`ufc_predictor.analysis.aggregate_last_five_stats`.
+
+    If ``csv_path`` does not exist, an empty :class:`~pandas.DataFrame` is
+    returned and a message is printed.
     """
-    df = pd.read_csv(csv_path)
+    try:
+        df = pd.read_csv(csv_path)
+    except FileNotFoundError:
+        print(f"CSV file not found at {csv_path}")
+        return pd.DataFrame()
 
     # Sequential date placeholder to preserve chronological order per fighter
     df["date"] = df.groupby("Fighter").cumcount()


### PR DESCRIPTION
## Summary
- Return an empty DataFrame with a clear message when `fight_stats_raw.csv` is missing
- Add unit test to ensure `compute_last_five_stats` handles missing CSVs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e9abaddc08324ad49f7951bef9fdb