### PR TITLE
Refactor training setup for lazy data loading

### DIFF
--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -4,6 +4,7 @@ import sys
 import numpy as np
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
+import types
 
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -44,17 +45,29 @@ class DummyStackingClassifier:
 def test_train_split_deterministic(tmp_path, monkeypatch):
     X = pd.DataFrame({"feat": range(12)})
     y = [0, 1] * 6
+    fight_stats = X.assign(Winner=y)
+    fight_stats.to_csv(tmp_path / "fight_stats.csv", index=False)
+    pd.DataFrame(["feat", "feat"]).to_csv(
+        tmp_path / "columnas_X.csv", index=False, header=False
+    )
 
-    train_model.X = X
-    train_model.fight_stats = X.assign(Winner=y)
-    train_model.models = {
-        "LogReg": (LogisticRegression(random_state=train_model.RANDOM_STATE), {})
-    }
-    train_model.MODELS_DIR = tmp_path
+    train_model.DATA_DIR = tmp_path
+    train_model.MODELS_BASE_DIR = str(tmp_path)
 
     monkeypatch.setattr(train_model.joblib, "dump", lambda *args, **kwargs: None)
     monkeypatch.setattr(train_model, "GridSearchCV", DummyGridSearchCV)
     monkeypatch.setattr(train_model, "StackingClassifier", DummyStackingClassifier)
+    monkeypatch.setattr(
+        train_model,
+        "_build_models",
+        lambda *args: {
+            "LogReg": (LogisticRegression(random_state=train_model.RANDOM_STATE), {})
+        },
+    )
+
+    monkeypatch.setitem(sys.modules, "xgboost", types.SimpleNamespace(XGBClassifier=LogisticRegression))
+    monkeypatch.setitem(sys.modules, "lightgbm", types.SimpleNamespace(LGBMClassifier=LogisticRegression))
+    monkeypatch.setitem(sys.modules, "catboost", types.SimpleNamespace(CatBoostClassifier=LogisticRegression))
 
     splits = []
     real_tts = train_model.train_test_split

--- a/train_model.py
+++ b/train_model.py
@@ -17,86 +17,71 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score, roc_auc_score
 from sklearn.model_selection import GridSearchCV, StratifiedKFold, train_test_split
 from sklearn.svm import SVC
-from lightgbm import LGBMClassifier
-from xgboost import XGBClassifier
-from catboost import CatBoostClassifier
 
 from ufc_predictor.config import MODEL_VERSION
 
 RANDOM_STATE = 42
 
 DATA_DIR = os.path.abspath("data")
-MODELS_DIR = os.path.abspath(os.path.join("models", MODEL_VERSION))
-os.makedirs(MODELS_DIR, exist_ok=True)
+MODELS_BASE_DIR = "models"
+MODELS_DIR: str | None = None
 
-try:
-    fight_stats = pd.read_csv(os.path.join(DATA_DIR, "fight_stats.csv"))
-except FileNotFoundError:
-    print("❌ No se encontró 'data/fight_stats.csv'. Genera este archivo antes de entrenar.")
-    raise SystemExit(1)
 
-try:
-    columnas_X = (
-        pd.read_csv(os.path.join(DATA_DIR, "columnas_X.csv"), header=None)
-        .squeeze()
-        .tolist()
-    )
-except FileNotFoundError:
-    print("❌ No se encontró 'data/columnas_X.csv'. Asegúrate de crear este archivo.")
-    raise SystemExit(1)
-
-X = fight_stats[columnas_X]
-
-models = {
-    "XGBoost": (
-        XGBClassifier(random_state=RANDOM_STATE),
-        {
-            "learning_rate": [0.01, 0.1],
-            "n_estimators": [100, 200],
-            "max_depth": [3, 5, 7],
-        },
-    ),
-    "LightGBM": (
-        LGBMClassifier(random_state=RANDOM_STATE),
-        {
-            "learning_rate": [0.01, 0.1],
-            "n_estimators": [100, 200],
-            "max_depth": [3, 5, 7],
-        },
-    ),
-    "CatBoost": (
-        CatBoostClassifier(verbose=0, random_state=RANDOM_STATE),
-        {"learning_rate": [0.01, 0.1], "iterations": [100, 200]},
-    ),
-    "RandomForest": (
-        RandomForestClassifier(random_state=RANDOM_STATE),
-        {
-            "n_estimators": [100, 200],
-            "max_depth": [10, 20],
-            "min_samples_split": [2, 5],
-        },
-    ),
-    "GradientBoosting": (
-        GradientBoostingClassifier(random_state=RANDOM_STATE),
-        {
-            "learning_rate": [0.01, 0.1],
-            "n_estimators": [100, 200],
-            "max_depth": [3, 5, 7],
-        },
-    ),
-    "LogisticRegression": (
-        LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
-        {"C": [0.1, 1, 10], "solver": ["lbfgs", "liblinear"]},
-    ),
-    "SVC": (
-        SVC(probability=True, random_state=RANDOM_STATE),
-        {"C": [0.1, 1, 10], "kernel": ["linear", "rbf"]},
-    ),
-}
+def _build_models(XGBClassifier, LGBMClassifier, CatBoostClassifier):
+    """Return dictionary of base models and parameter grids."""
+    return {
+        "XGBoost": (
+            XGBClassifier(random_state=RANDOM_STATE),
+            {
+                "learning_rate": [0.01, 0.1],
+                "n_estimators": [100, 200],
+                "max_depth": [3, 5, 7],
+            },
+        ),
+        "LightGBM": (
+            LGBMClassifier(random_state=RANDOM_STATE),
+            {
+                "learning_rate": [0.01, 0.1],
+                "n_estimators": [100, 200],
+                "max_depth": [3, 5, 7],
+            },
+        ),
+        "CatBoost": (
+            CatBoostClassifier(verbose=0, random_state=RANDOM_STATE),
+            {"learning_rate": [0.01, 0.1], "iterations": [100, 200]},
+        ),
+        "RandomForest": (
+            RandomForestClassifier(random_state=RANDOM_STATE),
+            {
+                "n_estimators": [100, 200],
+                "max_depth": [10, 20],
+                "min_samples_split": [2, 5],
+            },
+        ),
+        "GradientBoosting": (
+            GradientBoostingClassifier(random_state=RANDOM_STATE),
+            {
+                "learning_rate": [0.01, 0.1],
+                "n_estimators": [100, 200],
+                "max_depth": [3, 5, 7],
+            },
+        ),
+        "LogisticRegression": (
+            LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
+            {"C": [0.1, 1, 10], "solver": ["lbfgs", "liblinear"]},
+        ),
+        "SVC": (
+            SVC(probability=True, random_state=RANDOM_STATE),
+            {"C": [0.1, 1, 10], "kernel": ["linear", "rbf"]},
+        ),
+    }
 
 
 def train(target_column: str) -> None:
     """Entrena modelos base y un stacking final para ``target_column``.
+
+    La función carga datos y dependencias de forma perezosa y mostrará un
+    mensaje amigable si faltan archivos requeridos o librerías opcionales.
 
     Parameters
     ----------
@@ -104,10 +89,49 @@ def train(target_column: str) -> None:
         Nombre de la columna objetivo, por ejemplo ``"Method"`` o ``"Winner"``.
     """
 
+    global MODELS_DIR
+
+    try:
+        from xgboost import XGBClassifier
+        from lightgbm import LGBMClassifier
+        from catboost import CatBoostClassifier
+    except ModuleNotFoundError:
+        print(
+            "❌ Faltan dependencias opcionales (xgboost, lightgbm o catboost). "
+            "Instálalas antes de entrenar."
+        )
+        return
+
+    MODELS_DIR = os.path.abspath(os.path.join(MODELS_BASE_DIR, MODEL_VERSION))
+    os.makedirs(MODELS_DIR, exist_ok=True)
+
+    try:
+        fight_stats = pd.read_csv(os.path.join(DATA_DIR, "fight_stats.csv"))
+    except FileNotFoundError:
+        print(
+            "❌ No se encontró 'data/fight_stats.csv'. Genera este archivo antes de entrenar."
+        )
+        return
+
+    try:
+        columnas_X = (
+            pd.read_csv(os.path.join(DATA_DIR, "columnas_X.csv"), header=None)
+            .squeeze()
+            .tolist()
+        )
+    except FileNotFoundError:
+        print(
+            "❌ No se encontró 'data/columnas_X.csv'. Asegúrate de crear este archivo."
+        )
+        return
+
+    X = fight_stats[columnas_X]
     y = fight_stats[target_column]
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, random_state=RANDOM_STATE
     )
+
+    models = _build_models(XGBClassifier, LGBMClassifier, CatBoostClassifier)
 
     cv = StratifiedKFold(n_splits=3, shuffle=True, random_state=RANDOM_STATE)
     mejores = []
@@ -125,6 +149,7 @@ def train(target_column: str) -> None:
         )
         mejores.append((nombre, grid.best_estimator_))
         print(f"✅ {nombre} mejores parámetros: {grid.best_params_}")
+
     stacking = StackingClassifier(
         estimators=mejores,
         final_estimator=LogisticRegression(random_state=RANDOM_STATE),


### PR DESCRIPTION
## Summary
- Load optional XGBoost/LightGBM/CatBoost imports within `train` and guard against missing dependencies
- Move dataset loading and model directory creation inside `train`
- Update `train` docstring to note friendly messaging when dependencies or data are absent
- Rework unit test to inject data and models after importing the module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e9abed7c88324af214dc73c57569b