### PR TITLE
Defer model imports and data loading to train function

### DIFF
--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -41,12 +41,13 @@ def test_train_split_deterministic(tmp_path, monkeypatch):
     X = pd.DataFrame({"feat": range(12)})
     y = [0, 1] * 6
 
-    train_module.X = X
-    train_module.fight_stats = X.assign(Winner=y)
-    train_module.models = {
+    fight_stats = X.assign(Winner=y)
+    fight_stats.to_csv(tmp_path / "fight_stats.csv", index=False)
+    pd.Series(["feat"]).to_csv(tmp_path / "columnas_X.csv", index=False, header=False)
+
+    models = {
         "LogReg": (LogisticRegression(random_state=train_module.RANDOM_STATE), {})
     }
-    train_module.MODELS_DIR = tmp_path
 
     monkeypatch.setattr(train_module.joblib, "dump", lambda *args, **kwargs: None)
     monkeypatch.setattr(train_module, "GridSearchCV", DummyGridSearchCV)
@@ -62,8 +63,8 @@ def test_train_split_deterministic(tmp_path, monkeypatch):
 
     monkeypatch.setattr(train_module, "train_test_split", record_split)
 
-    train("Winner")
-    train("Winner")
+    train("Winner", data_dir=str(tmp_path), models_dir=str(tmp_path), models=models)
+    train("Winner", data_dir=str(tmp_path), models_dir=str(tmp_path), models=models)
 
     (X_train1, X_test1, y_train1, y_test1), (X_train2, X_test2, y_train2, y_test2) = splits
 

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -19,94 +19,118 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score, roc_auc_score
 from sklearn.model_selection import GridSearchCV, StratifiedKFold, train_test_split
 from sklearn.svm import SVC
-from lightgbm import LGBMClassifier
-from xgboost import XGBClassifier
-from catboost import CatBoostClassifier
 
 from ufc_predictor.config import MODEL_VERSION
 
 RANDOM_STATE = 42
 
 DATA_DIR = os.path.abspath("data")
-MODELS_DIR = os.path.abspath(os.path.join("models", MODEL_VERSION))
-os.makedirs(MODELS_DIR, exist_ok=True)
-
-try:
-    fight_stats = pd.read_csv(os.path.join(DATA_DIR, "fight_stats.csv"))
-except FileNotFoundError:
-    print("❌ No se encontró 'data/fight_stats.csv'. Genera este archivo antes de entrenar.")
-    raise SystemExit(1)
-
-try:
-    columnas_X = (
-        pd.read_csv(os.path.join(DATA_DIR, "columnas_X.csv"), header=None)
-        .squeeze()
-        .tolist()
-    )
-except FileNotFoundError:
-    print("❌ No se encontró 'data/columnas_X.csv'. Asegúrate de crear este archivo.")
-    raise SystemExit(1)
-
-X = fight_stats[columnas_X]
-
-models = {
-    "XGBoost": (
-        XGBClassifier(random_state=RANDOM_STATE),
-        {
-            "learning_rate": [0.01, 0.1],
-            "n_estimators": [100, 200],
-            "max_depth": [3, 5, 7],
-        },
-    ),
-    "LightGBM": (
-        LGBMClassifier(random_state=RANDOM_STATE),
-        {
-            "learning_rate": [0.01, 0.1],
-            "n_estimators": [100, 200],
-            "max_depth": [3, 5, 7],
-        },
-    ),
-    "CatBoost": (
-        CatBoostClassifier(verbose=0, random_state=RANDOM_STATE),
-        {"learning_rate": [0.01, 0.1], "iterations": [100, 200]},
-    ),
-    "RandomForest": (
-        RandomForestClassifier(random_state=RANDOM_STATE),
-        {
-            "n_estimators": [100, 200],
-            "max_depth": [10, 20],
-            "min_samples_split": [2, 5],
-        },
-    ),
-    "GradientBoosting": (
-        GradientBoostingClassifier(random_state=RANDOM_STATE),
-        {
-            "learning_rate": [0.01, 0.1],
-            "n_estimators": [100, 200],
-            "max_depth": [3, 5, 7],
-        },
-    ),
-    "LogisticRegression": (
-        LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
-        {"C": [0.1, 1, 10], "solver": ["lbfgs", "liblinear"]},
-    ),
-    "SVC": (
-        SVC(probability=True, random_state=RANDOM_STATE),
-        {"C": [0.1, 1, 10], "kernel": ["linear", "rbf"]},
-    ),
-}
 
 
-def train(target_column: str) -> None:
+def train(
+    target_column: str,
+    data_dir: str = DATA_DIR,
+    models_dir: str | None = None,
+    models: dict | None = None,
+) -> None:
     """Entrena modelos base y un stacking final para ``target_column``.
 
     Parameters
     ----------
     target_column:
         Nombre de la columna objetivo, por ejemplo ``"Method"`` o ``"Winner"``.
+    data_dir:
+        Directorio donde se encuentran ``fight_stats.csv`` y ``columnas_X.csv``.
+    models_dir:
+        Directorio donde se guardarán los modelos entrenados. Si ``None`` se
+        utiliza ``models/{MODEL_VERSION}``.
+    models:
+        Diccionario opcional con los modelos a entrenar. Si no se provee se
+        utilizan los modelos por defecto y se importan las dependencias
+        pesadas dentro de esta función.
     """
 
+    if models_dir is None:
+        models_dir = os.path.abspath(os.path.join("models", MODEL_VERSION))
+    os.makedirs(models_dir, exist_ok=True)
+
+    try:
+        fight_stats = pd.read_csv(os.path.join(data_dir, "fight_stats.csv"))
+    except FileNotFoundError:
+        print(
+            "❌ No se encontró 'data/fight_stats.csv'. Genera este archivo antes de entrenar."
+        )
+        raise SystemExit(1)
+
+    try:
+        columnas_X = pd.read_csv(
+            os.path.join(data_dir, "columnas_X.csv"), header=None
+        ).squeeze()
+        if isinstance(columnas_X, str):
+            columnas_X = [columnas_X]
+        else:
+            columnas_X = columnas_X.tolist()
+    except FileNotFoundError:
+        print(
+            "❌ No se encontró 'data/columnas_X.csv'. Asegúrate de crear este archivo."
+        )
+        raise SystemExit(1)
+
+    X = fight_stats[columnas_X]
     y = fight_stats[target_column]
+
+    if models is None:
+        from lightgbm import LGBMClassifier
+        from xgboost import XGBClassifier
+        from catboost import CatBoostClassifier
+
+        models = {
+            "XGBoost": (
+                XGBClassifier(random_state=RANDOM_STATE),
+                {
+                    "learning_rate": [0.01, 0.1],
+                    "n_estimators": [100, 200],
+                    "max_depth": [3, 5, 7],
+                },
+            ),
+            "LightGBM": (
+                LGBMClassifier(random_state=RANDOM_STATE),
+                {
+                    "learning_rate": [0.01, 0.1],
+                    "n_estimators": [100, 200],
+                    "max_depth": [3, 5, 7],
+                },
+            ),
+            "CatBoost": (
+                CatBoostClassifier(verbose=0, random_state=RANDOM_STATE),
+                {"learning_rate": [0.01, 0.1], "iterations": [100, 200]},
+            ),
+            "RandomForest": (
+                RandomForestClassifier(random_state=RANDOM_STATE),
+                {
+                    "n_estimators": [100, 200],
+                    "max_depth": [10, 20],
+                    "min_samples_split": [2, 5],
+                },
+            ),
+            "GradientBoosting": (
+                GradientBoostingClassifier(random_state=RANDOM_STATE),
+                {
+                    "learning_rate": [0.01, 0.1],
+                    "n_estimators": [100, 200],
+                    "max_depth": [3, 5, 7],
+                },
+            ),
+            "LogisticRegression": (
+                LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
+                {"C": [0.1, 1, 10], "solver": ["lbfgs", "liblinear"]},
+            ),
+            "SVC": (
+                SVC(probability=True, random_state=RANDOM_STATE),
+                {"C": [0.1, 1, 10], "kernel": ["linear", "rbf"]},
+            ),
+        }
+
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, random_state=RANDOM_STATE
     )
@@ -123,10 +147,11 @@ def train(target_column: str) -> None:
         grid.fit(X_train, y_train)
         joblib.dump(
             grid.best_estimator_,
-            os.path.join(MODELS_DIR, f"{nombre.lower()}_{target_suffix}.pkl"),
+            os.path.join(models_dir, f"{nombre.lower()}_{target_suffix}.pkl"),
         )
         mejores.append((nombre, grid.best_estimator_))
         print(f"✅ {nombre} mejores parámetros: {grid.best_params_}")
+
     stacking = StackingClassifier(
         estimators=mejores,
         final_estimator=LogisticRegression(random_state=RANDOM_STATE),
@@ -134,7 +159,7 @@ def train(target_column: str) -> None:
         n_jobs=-1,
     )
     stacking.fit(X_train, y_train)
-    joblib.dump(stacking, os.path.join(MODELS_DIR, f"stacking_{target_suffix}.pkl"))
+    joblib.dump(stacking, os.path.join(models_dir, f"stacking_{target_suffix}.pkl"))
 
     y_pred = stacking.predict(X_test)
     y_proba = stacking.predict_proba(X_test)
@@ -150,7 +175,7 @@ def train(target_column: str) -> None:
     print(f"ROC-AUC: {roc_auc:.4f}")
     print(f"Random state: {RANDOM_STATE}\n")
 
-    with open(os.path.join(MODELS_DIR, f"metrics_{target_suffix}.txt"), "w") as f:
+    with open(os.path.join(models_dir, f"metrics_{target_suffix}.txt"), "w") as f:
         f.write(f"Accuracy: {accuracy:.4f}\n")
         f.write(f"ROC-AUC: {roc_auc:.4f}\n")
         f.write(f"Random state: {RANDOM_STATE}\n")


### PR DESCRIPTION
## Summary
- Load `fight_stats.csv` and `columnas_X.csv` within `train`, creating the models directory at runtime and handling missing files gracefully.
- Import heavy model libraries inside `train` and allow passing custom models and paths for flexible testing.
- Update tests to write temporary training data and invoke `train` after data injection.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ea9688000832486e5571aec512f55