### PR TITLE
Handle empty fight stats exports

### DIFF
--- a/tests/test_fight_stats.py
+++ b/tests/test_fight_stats.py
@@ -1,4 +1,6 @@
 import pandas as pd
+import runpy
+import pytest
 
 from ufc_predictor.fight_stats import compute_last_five_stats
 
@@ -10,3 +12,17 @@ def test_compute_last_five_stats_missing_csv(tmp_path, capsys):
     assert isinstance(df, pd.DataFrame)
     assert df.empty
     assert "not found" in captured.out.lower()
+
+
+def test_main_exits_when_no_data(monkeypatch, capsys):
+    def fake_read_csv(*args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(pd, "read_csv", fake_read_csv)
+
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_module("ufc_predictor.fight_stats", run_name="__main__")
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "No stats generated; skipping export." in captured.out

--- a/ufc_predictor/fight_stats.py
+++ b/ufc_predictor/fight_stats.py
@@ -104,6 +104,10 @@ def compute_last_five_stats(csv_path: str | Path = DATA_DIR / "fight_stats_raw.c
 
 if __name__ == "__main__":
     fight_stats = compute_last_five_stats()
+    if fight_stats.empty:
+        print("No stats generated; skipping export.")
+        raise SystemExit(1)
+
     DATA_DIR.mkdir(exist_ok=True)
     fight_stats.to_csv(DATA_DIR / "fight_stats.csv", index=False)
 


### PR DESCRIPTION
## Summary
- prevent fight stats export when no data is generated
- test that fight_stats exits when no data produced

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0b9fc10988324b9bd5b76989f6732