### PR TITLE
Encode training labels and persist encoder

### DIFF
--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -122,7 +122,14 @@ def train(
         columnas_procesadas = [c for c in columnas_procesadas if c not in no_numericas]
 
     y = fight_stats[target_column]
-
+    encoder = LabelEncoder()
+    y = pd.Series(encoder.fit_transform(y), name=target_column)
+    joblib.dump(
+        encoder,
+        os.path.join(models_dir, f"label_encoder_{target_column.lower()}.pkl"),
+    )
+    target_suffix = target_column.lower()
+    min_clase = y.value_counts().min()
 
     if models is None:
         from lightgbm import LGBMClassifier


### PR DESCRIPTION
## Summary
- Encode target labels during training using `LabelEncoder`
- Persist the fitted label encoder for later decoding
- Use encoded labels for splitting and evaluation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1313c29a48324977cd741e720c655