### PR TITLE
Compute min_clase and target_suffix after encoding target variable

### DIFF
--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -122,6 +122,10 @@ def train(
         columnas_procesadas = [c for c in columnas_procesadas if c not in no_numericas]
 
     y = fight_stats[target_column]
+    encoder = LabelEncoder()
+    y = pd.Series(encoder.fit_transform(y), name=target_column)
+    min_clase = y.value_counts().min()
+    target_suffix = target_column.lower()
 
 
     if models is None:


### PR DESCRIPTION
## Summary
- Encode target `y` and derive `min_clase` for fold count
- Add `target_suffix` based on target column name for output filenames

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1313c96dc8324af4a036976bface9