### PR TITLE
Reduce hyperparameter grids for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ Para entrenar el modelo del ganador del combate:
 python entrenamiento_winner.py
 ```
 
+### Ajustes rápidos en CI
+
+Para acelerar la integración continua, los grids de hiperparámetros en
+`ufc_predictor/train.py` usan valores reducidos.  Por ejemplo,
+`n_estimators` se limita a `[50, 100]`, `max_depth` a `[3, 5]` y
+`learning_rate` queda fijo en `0.1`, lo que implica menos de 50 "fits" por
+modelo con validación cruzada de 3 pliegues.  Realiza la búsqueda completa
+fuera del entorno de CI ampliando estas combinaciones.
+
 ## 📊 Agregación vs Dataset Rolling
 
 - `ufc_predictor.analysis.aggregate_last_five_stats`: produce un único registro por

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -136,31 +136,35 @@ def train(
         from xgboost import XGBClassifier
         from catboost import CatBoostClassifier
 
+        # Hyperparameter grids are intentionally small to keep CI runtime low.  With
+        # ``n_splits=3`` the largest grid below yields <50 fits.  For thorough
+        # experiments, expand these ranges offline (e.g. include more
+        # ``learning_rate`` values or deeper ``max_depth``).
         models = {
             "XGBoost": (
                 XGBClassifier(random_state=RANDOM_STATE),
                 {
-                    "learning_rate": [0.01, 0.1],
-                    "n_estimators": [100, 200],
-                    "max_depth": [3, 5, 7],
+                    "learning_rate": [0.1],
+                    "n_estimators": [50, 100],
+                    "max_depth": [3, 5],
                 },
             ),
             "LightGBM": (
                 LGBMClassifier(random_state=RANDOM_STATE),
                 {
-                    "learning_rate": [0.01, 0.1],
-                    "n_estimators": [100, 200],
-                    "max_depth": [3, 5, 7],
+                    "learning_rate": [0.1],
+                    "n_estimators": [50, 100],
+                    "max_depth": [3, 5],
                 },
             ),
             "CatBoost": (
                 CatBoostClassifier(verbose=0, random_state=RANDOM_STATE),
-                {"learning_rate": [0.01, 0.1], "iterations": [100, 200]},
+                {"learning_rate": [0.1], "iterations": [50, 100]},
             ),
             "RandomForest": (
                 RandomForestClassifier(random_state=RANDOM_STATE),
                 {
-                    "n_estimators": [100, 200],
+                    "n_estimators": [50, 100],
                     "max_depth": [10, 20],
                     "min_samples_split": [2, 5],
                 },
@@ -168,9 +172,9 @@ def train(
             "GradientBoosting": (
                 GradientBoostingClassifier(random_state=RANDOM_STATE),
                 {
-                    "learning_rate": [0.01, 0.1],
-                    "n_estimators": [100, 200],
-                    "max_depth": [3, 5, 7],
+                    "learning_rate": [0.1],
+                    "n_estimators": [50, 100],
+                    "max_depth": [3, 5],
                 },
             ),
             "LogisticRegression": (


### PR DESCRIPTION
## Summary
- shrink training hyperparameter grids to stay under 50 fits per model
- document reduced grids for faster CI runs

## Testing
- `pytest -q`
- `python - <<'PY'
from sklearn.model_selection import ParameterGrid

grids = {
    "XGBoost": {"learning_rate": [0.1], "n_estimators": [50,100], "max_depth": [3,5]},
    "LightGBM": {"learning_rate": [0.1], "n_estimators": [50,100], "max_depth": [3,5]},
    "CatBoost": {"learning_rate": [0.1], "iterations": [50,100]},
    "RandomForest": {"n_estimators": [50,100], "max_depth": [10,20], "min_samples_split": [2,5]},
    "GradientBoosting": {"learning_rate": [0.1], "n_estimators": [50,100], "max_depth": [3,5]},
    "LogisticRegression": {"C": [0.1, 1, 10], "solver": ["lbfgs", "liblinear"]},
    "SVC": {"C": [0.1, 1, 10], "kernel": ["linear", "rbf"]},
}

splits = 3
for name, params in grids.items():
    combos = len(ParameterGrid(params))
    fits = combos * splits
    print(f"{name}: {combos} combinations -> {fits} fits")
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a27106d6f08324aea86e9f194a0ac5