### PR TITLE
feat: allow filtering models during training

### DIFF
--- a/.github/workflows/entrenamiento_dependiente.yml
+++ b/.github/workflows/entrenamiento_dependiente.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   entrenamiento:
     runs-on: ubuntu-latest
+    env:
+      MODEL_NAMES: XGBoost,LightGBM
 
     steps:
     - name: Checkout repo

--- a/entrenamiento.py
+++ b/entrenamiento.py
@@ -1,4 +1,8 @@
+import os
+
 from ufc_predictor.train import train
 
 if __name__ == "__main__":
-    train("Method")
+    model_names = os.getenv("MODEL_NAMES")
+    nombres = [m.strip() for m in model_names.split(",") if m.strip()] if model_names else None
+    train("Method", model_names=nombres)

--- a/entrenamiento_winner.py
+++ b/entrenamiento_winner.py
@@ -1,6 +1,9 @@
 
+import os
 
 from ufc_predictor.train import train
 
 if __name__ == "__main__":
-    train("Winner")
+    model_names = os.getenv("MODEL_NAMES")
+    nombres = [m.strip() for m in model_names.split(",") if m.strip()] if model_names else None
+    train("Winner", model_names=nombres)

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -33,6 +33,7 @@ def train(
     data_dir: str = DATA_DIR,
     models_dir: str | None = None,
     models: dict | None = None,
+    model_names: list[str] | None = None,
 ) -> None:
     """Entrena modelos base y un stacking final para ``target_column``.
 
@@ -49,6 +50,10 @@ def train(
         Diccionario opcional con los modelos a entrenar. Si no se provee se
         utilizan los modelos por defecto y se importan las dependencias
         pesadas dentro de esta función.
+    model_names:
+        Lista opcional con los nombres de modelos a ejecutar. Los nombres
+        deben coincidir con las claves del diccionario ``models``. Si es
+        ``None`` se entrenan todos los modelos disponibles.
 
     Notes
     -----
@@ -182,6 +187,12 @@ def train(
                 {"C": [0.1, 1, 10], "kernel": ["linear", "rbf"]},
             ),
         }
+
+    if model_names:
+        nombres = {n.lower() for n in model_names}
+        models = {k: v for k, v in models.items() if k.lower() in nombres}
+        if not models:
+            raise SystemExit("No se encontraron modelos válidos en model_names")
 
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, random_state=RANDOM_STATE


### PR DESCRIPTION
## Summary
- allow `train` to accept `model_names` to run specific estimators
- add MODEL_NAMES env var to dependent training workflow
- pass model selection from env var in training scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2710ad6548324a815a09fc5a5e232