### PR TITLE
Include fighter and event metadata in reduced stats

### DIFF
--- a/ufc_predictor/fight_stats.py
+++ b/ufc_predictor/fight_stats.py
@@ -112,7 +112,9 @@ if __name__ == "__main__":
     fight_stats.to_csv(DATA_DIR / "fight_stats.csv", index=False)
 
     reduced_cols = [
-
+        "Fighter",
+        "Format",
+        "Weight Class",
         "date",
         "form_last_5",
     ] + [c for c in fight_stats.columns if c.endswith("_rolling_mean")]


### PR DESCRIPTION
## Summary
- include fighter name, format, and weight class when exporting reduced fight stats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a531ca4ea88324903dcbe2247fe2fe