### PR TITLE
Preprocess fight stats columns for training

### DIFF
--- a/data/columnas_X.csv
+++ b/data/columnas_X.csv
@@ -1,9 +1,9 @@
-Weight Class
+Rounds
 Format
+Weight Class
 KD
 Sub. Att
 Reversal
-Rounds
 form_last_5
 landed_sig. str.
 atmp_sig. str.

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -122,6 +122,19 @@ def train(
     if not columnas_procesadas:
         raise SystemExit("No se pudieron alinear columnas para entrenamiento")
 
+    if "Rounds" in fight_stats.columns:
+        fight_stats["Rounds"] = pd.to_numeric(
+            fight_stats["Rounds"], errors="coerce"
+        )
+    if "Format" in fight_stats.columns:
+        fight_stats["Format"] = (
+            fight_stats["Format"].str.extract(r"(\d+)").astype(float)
+        )
+    if "Weight Class" in fight_stats.columns:
+        fight_stats["Weight Class"] = pd.Categorical(
+            fight_stats["Weight Class"]
+        ).codes
+
     X = fight_stats[columnas_procesadas]
     # Elimina columnas no numéricas que provocarían errores en los modelos
     no_numericas = X.select_dtypes(exclude="number").columns.tolist()


### PR DESCRIPTION
## Summary
- Convert fight rounds and format to numeric values
- Encode weight class categories
- Reorder feature list to start with Rounds, Format, and Weight Class

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a675f9a65c832496c66c39af38a63e