### PR TITLE
Refactor accuracy calculations in fight stats

### DIFF
--- a/ufc_predictor/fight_stats.py
+++ b/ufc_predictor/fight_stats.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 import pandas as pd
+import numpy as np
 
 DATA_DIR = Path("data")
 
@@ -81,22 +82,6 @@ def compute_last_five_stats(csv_path: str | Path = DATA_DIR / "fight_stats_raw.c
         df[f"landed_{base}"] = landed
         df[f"atmp_{base}"] = atmp
 
-    acc_bases = [
-        "sig_str",
-        "total_str",
-        "head",
-        "body",
-        "leg",
-        "distance",
-        "clinch",
-        "ground",
-    ]
-    acc_cols: list[str] = []
-    for base in acc_bases:
-        col_name = f"{base}_acc"
-        df[col_name] = df[f"landed_{base}"] / df[f"atmp_{base}"].replace(0, 1)
-        acc_cols.append(col_name)
-
     # Compute landed strikes per minute for selected categories
     fight_length_min = (
         df["Total_fight_length_sec"].replace(0, pd.NA).div(60).fillna(1)
@@ -121,7 +106,7 @@ def compute_last_five_stats(csv_path: str | Path = DATA_DIR / "fight_stats_raw.c
         lpm_cols.append(col_name)
 
     # Compute accuracy for landed versus attempted metrics
-    acc_bases = [
+    for base in [
         "sig_str",
         "total_str",
         "td",
@@ -131,13 +116,9 @@ def compute_last_five_stats(csv_path: str | Path = DATA_DIR / "fight_stats_raw.c
         "distance",
         "clinch",
         "ground",
-    ]
-    for base in acc_bases:
-        df[f"{base}_acc"] = (
-            df[f"landed_{base}"]
-            .div(df[f"atmp_{base}"].replace(0, pd.NA))
-            .fillna(0)
-        )
+    ]:
+        attempts = df[f"atmp_{base}"].replace(0, np.nan)
+        df[f"{base}_acc"] = (df[f"landed_{base}"] / attempts).fillna(0)
 
     # Columns for which we will compute rolling means
     rolling_cols = [


### PR DESCRIPTION
## Summary
- add numpy import for later calculations
- remove redundant early accuracy block
- compute accuracy using numpy.nan to avoid division by zero

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7b75b72bc83249833298fbde154c9