### PR TITLE
Handle numeric Format inputs

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,7 +85,7 @@ if "Rounds" in fight_stats.columns:
     )
 if "Format" in fight_stats.columns:
     fight_stats["Format"] = (
-        fight_stats["Format"].str.extract(r"(\d+)").astype(float)
+        fight_stats["Format"].astype(str).str.extract(r"(\d+)").astype(float)
     )
 if "Weight Class" in fight_stats.columns:
     weight_class_cat = pd.Categorical(fight_stats["Weight Class"])
@@ -188,7 +188,11 @@ else:
     # Convertir entradas del usuario al mismo código utilizado en el entrenamiento
     if "Format" in stats_features_1.columns:
         format_input_code = (
-            pd.Series([format_input]).str.extract(r"(\d+)").astype(float).iloc[0]
+            pd.Series([format_input])
+            .astype(str)
+            .str.extract(r"(\d+)")
+            .astype(float)
+            .iloc[0]
         )
         stats_features_1["Format"] = format_input_code
         stats_features_2["Format"] = format_input_code


### PR DESCRIPTION
## Summary
- Prevent AttributeError when extracting rounds format by converting `Format` values to string before regex extraction.
- Update user input handling to safely parse numeric or string format values and reassign them to model features.

## Testing
- `python - <<'PY'
import pandas as pd
for value in [3.0, '5 rounds']:
    code = (
        pd.Series([value]).astype(str).str.extract(r'(\d+)').astype(float).iloc[0,0]
    )
    print(value, '->', code)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a89d7ee80c83249be4cbef83ed85e0