### PR TITLE
Remove win feature from model inputs

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,7 +56,10 @@ def _sanitize(name: str) -> str:
 
 # Asegurarse de que las columnas del modelo se carguen correctamente
 try:
-    columnas_X_raw = pd.read_csv("data/columnas_X.csv", header=None).squeeze().tolist()
+    columnas_X_raw = (
+        pd.read_csv("data/columnas_X.csv", header=None).squeeze().tolist()
+    )
+    columnas_X_raw = [c for c in columnas_X_raw if c.lower() != "win"]
 except FileNotFoundError:
     st.error("Archivo de columnas no encontrado: data/columnas_X.csv")
     st.stop()
@@ -184,6 +187,8 @@ else:
 
     stats_features_1 = stats_fighter_1[columnas_X].copy()
     stats_features_2 = stats_fighter_2[columnas_X].copy()
+    stats_features_1 = stats_features_1.drop(columns=['win'], errors='ignore')
+    stats_features_2 = stats_features_2.drop(columns=['win'], errors='ignore')
 
     # Convertir entradas del usuario al mismo código utilizado en el entrenamiento
     if "Format" in stats_features_1.columns:

--- a/data/columnas_X.csv
+++ b/data/columnas_X.csv
@@ -1,5 +1,4 @@
 date
-win
 form_last_5
 landed_sig_str
 atmp_sig_str


### PR DESCRIPTION
## Summary
- Drop `win` from feature list used in modeling.
- Guard Streamlit app against using `win` in fighter feature sets.

## Testing
- `python - <<'PY'
from ufc_predictor.train import train
train('Winner', fast_mode=True, models_dir='/tmp/models_temp2')
PY`
- `python - <<'PY'
import pandas as pd, joblib

fight_stats = pd.read_csv('data/fight_stats.csv')
columnas_X = pd.read_csv('data/columnas_X.csv', header=None).squeeze().tolist()
columnas_X = [c for c in columnas_X if c.lower() != 'win']

if 'Rounds' in fight_stats.columns:
    fight_stats['Rounds'] = pd.to_numeric(fight_stats['Rounds'], errors='coerce')
if 'Format' in fight_stats.columns:
    fight_stats['Format'] = fight_stats['Format'].astype(str).str.extract(r'(\\d+)').astype(float)
if 'Weight Class' in fight_stats.columns:
    fight_stats['Weight Class'] = pd.Categorical(fight_stats['Weight Class']).codes

fighters = fight_stats['Fighter'].unique()
f1, f2 = fighters[0], fighters[1]

stats_f1 = fight_stats[fight_stats['Fighter'] == f1].sort_values('date', ascending=False).head(1)
stats_f2 = fight_stats[fight_stats['Fighter'] == f2].sort_values('date', ascending=False).head(1)

stats_features_1 = stats_f1[columnas_X].copy().drop(columns=['win'], errors='ignore')
stats_features_2 = stats_f2[columnas_X].copy().drop(columns=['win'], errors='ignore')

model = joblib.load('models/1.0_temp/stacking_winner.pkl')
proba1 = model.predict_proba(stats_features_1)[0][1]
proba2 = model.predict_proba(stats_features_2)[0][1]

p1 = proba1/(proba1+proba2)*100
p2 = proba2/(proba1+proba2)*100

print(f"Fighters: {f1} vs {f2}")
print(f"Winner probs: {p1:.2f}% vs {p2:.2f}%")
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8a8f524248324906cdb5b47e4b0e9