### PR TITLE
Handle varied physical metrics formats with regex

### DIFF
--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -14,16 +14,40 @@ def test_convert_height_to_cm_malformed():
     assert convert_height_to_cm("bad format") is None
 
 
+def test_convert_height_to_cm_variants():
+    assert convert_height_to_cm("6'2\"") == pytest.approx(187.96, abs=0.01)
+    assert convert_height_to_cm("6ft2in") == pytest.approx(187.96, abs=0.01)
+    assert convert_height_to_cm("6ft") == pytest.approx(182.88, abs=0.01)
+    assert convert_height_to_cm("180cm") is None
+
+
 def test_convert_weight_to_kg_malformed():
     assert convert_weight_to_kg("--") is None
     assert convert_weight_to_kg("") is None
     assert convert_weight_to_kg("bad format") is None
 
 
+def test_convert_weight_to_kg_variants():
+    expected = 170 * 0.453592
+    assert convert_weight_to_kg("170 lb") == pytest.approx(expected, abs=0.01)
+    assert convert_weight_to_kg("170lbs") == pytest.approx(expected, abs=0.01)
+    assert convert_weight_to_kg("170lb") == pytest.approx(expected, abs=0.01)
+    assert convert_weight_to_kg("170 lbs.") == pytest.approx(expected, abs=0.01)
+    assert convert_weight_to_kg("80kg") is None
+
+
 def test_convert_reach_to_cm_malformed():
     assert convert_reach_to_cm("--") is None
     assert convert_reach_to_cm("") is None
     assert convert_reach_to_cm("bad format") is None
+
+
+def test_convert_reach_to_cm_variants():
+    expected = 70 * 2.54
+    assert convert_reach_to_cm('70"') == pytest.approx(expected, abs=0.01)
+    assert convert_reach_to_cm('70in') == pytest.approx(expected, abs=0.01)
+    assert convert_reach_to_cm('70 in.') == pytest.approx(expected, abs=0.01)
+    assert convert_reach_to_cm('180cm') is None
 
 
 def test_preprocess_fighters_birthdate_null_values():

--- a/ufc_predictor/preprocessing.py
+++ b/ufc_predictor/preprocessing.py
@@ -1,39 +1,64 @@
 
 from __future__ import annotations
+
 import re
 import pandas as pd
 
 
 def convert_height_to_cm(height: str) -> float | None:
-    """Convert a height value like ``6' 2\"`` to centimeters."""
-    if height and height != "--":
-        try:
-            feet, inches = height.split("' ")
-            inches = inches.replace('"', '')
-            return int(feet) * 30.48 + int(inches) * 2.54
-        except ValueError:
-            return None
-    return None
+    """Convert height strings like ``6'2"`` or ``6ft2in`` to centimeters."""
+
+    if not height or height == "--":
+        return None
+
+    match = re.match(
+        r"^\s*(?P<feet>\d+)\s*(?:ft|')\s*(?P<inches>\d*)\s*(?:in|\"|inches)?\s*$",
+        height,
+        flags=re.IGNORECASE,
+    )
+
+    if not match:
+        return None
+
+    feet = int(match.group("feet"))
+    inches = int(match.group("inches")) if match.group("inches") else 0
+    return feet * 30.48 + inches * 2.54
 
 
 def convert_weight_to_kg(weight: str) -> float | None:
-    """Convert a weight value like ``170 lbs."`` to kilograms."""
-    if weight and weight != "--":
-        try:
-            return float(weight.replace(' lbs.', '')) * 0.453592
-        except ValueError:
-            return None
-    return None
+    """Convert weight strings like ``170lb`` or ``170 lbs.`` to kilograms."""
+
+    if not weight or weight == "--":
+        return None
+
+    match = re.match(
+        r"^\s*(?P<weight>\d+(?:\.\d+)?)\s*(?:(?:lbs?|pounds?)\.?)?\s*$",
+        weight,
+        flags=re.IGNORECASE,
+    )
+
+    if not match:
+        return None
+
+    return float(match.group("weight")) * 0.453592
 
 
 def convert_reach_to_cm(reach: str) -> float | None:
-    """Convert a reach measurement in inches to centimeters."""
-    if reach and reach != "--":
-        try:
-            return float(reach.replace('"', '')) * 2.54
-        except ValueError:
-            return None
-    return None
+    """Convert reach measurements like ``70in`` or ``70\"`` to centimeters."""
+
+    if not reach or reach == "--":
+        return None
+
+    match = re.match(
+        r"^\s*(?P<reach>\d+(?:\.\d+)?)\s*(?:in|\"|inches)?\.?\s*$",
+        reach,
+        flags=re.IGNORECASE,
+    )
+
+    if not match:
+        return None
+
+    return float(match.group("reach")) * 2.54
 
 
 def preprocess_fighters(df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- Improve height, weight and reach conversion helpers using regex to handle spaces and unit variations
- Expand preprocessing tests for alternate formats and malformed values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a91305daf08324a86f30eca252b07a