### PR TITLE
Use median imputation with missing indicators for fighter stats

### DIFF
--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -46,3 +46,40 @@ def test_preprocess_fighters_birthdate_null_values():
     assert (processed.loc[processed["full_name"] == "F1", "birthdate"].item()) == "N/A"
     assert (processed.loc[processed["full_name"] == "F2", "birthdate"].item()) == "N/A"
 
+
+def test_preprocess_fighters_imputes_missing_and_flags():
+    df = pd.DataFrame(
+        {
+            "full_name": ["F1", "F2", "F3"],
+            "height": ["6' 0\"", None, "5' 8\""],
+            "weight": ["170 lbs.", "145 lbs.", None],
+            "reach": ["70\"", "68\"", None],
+            "stance": ["Orthodox", "Southpaw", "Orthodox"],
+            "wins": [10, 5, 7],
+            "losses": [2, 3, 4],
+            "draws": [0, 1, 0],
+            "birthdate": ["Jan 01, 1990", "Feb 02, 1992", None],
+        }
+    )
+
+    processed = preprocess_fighters(df)
+
+    assert processed.loc[processed["full_name"] == "F2", "height_missing"].item()
+    assert not processed.loc[processed["full_name"] == "F1", "height_missing"].item()
+    assert processed.loc[processed["full_name"] == "F3", "weight_missing"].item()
+    assert processed.loc[processed["full_name"] == "F3", "reach_missing"].item()
+
+    expected_height = (convert_height_to_cm("6' 0\"") + convert_height_to_cm("5' 8\"")) / 2
+    expected_weight = (convert_weight_to_kg("170 lbs.") + convert_weight_to_kg("145 lbs.")) / 2
+    expected_reach = (convert_reach_to_cm("70\"") + convert_reach_to_cm("68\"")) / 2
+
+    assert processed.loc[processed["full_name"] == "F2", "height_cm"].item() == pytest.approx(
+        expected_height
+    )
+    assert processed.loc[processed["full_name"] == "F3", "weight_kg"].item() == pytest.approx(
+        expected_weight
+    )
+    assert processed.loc[processed["full_name"] == "F3", "reach_cm"].item() == pytest.approx(
+        expected_reach
+    )
+

--- a/ufc_predictor/preprocessing.py
+++ b/ufc_predictor/preprocessing.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import re
 import pandas as pd
+from sklearn.impute import SimpleImputer
 
 
 def convert_height_to_cm(height: str) -> float | None:
@@ -60,9 +61,14 @@ def preprocess_fighters(df: pd.DataFrame) -> pd.DataFrame:
     df["weight_kg"] = df["weight"].apply(convert_weight_to_kg)
     df["reach_cm"] = df["reach"].apply(convert_reach_to_cm)
 
-    df["height_cm"].fillna(0, inplace=True)
-    df["weight_kg"].fillna(0, inplace=True)
-    df["reach_cm"].fillna(0, inplace=True)
+    df["height_missing"] = df["height_cm"].isna()
+    df["weight_missing"] = df["weight_kg"].isna()
+    df["reach_missing"] = df["reach_cm"].isna()
+
+    imputer = SimpleImputer(strategy="median")
+    df[["height_cm", "weight_kg", "reach_cm"]] = imputer.fit_transform(
+        df[["height_cm", "weight_kg", "reach_cm"]]
+    )
 
     df["birthdate"] = df["birthdate"].apply(
         lambda x: (
@@ -78,8 +84,11 @@ def preprocess_fighters(df: pd.DataFrame) -> pd.DataFrame:
             "fighter_id",
             "full_name",
             "height_cm",
+            "height_missing",
             "weight_kg",
+            "weight_missing",
             "reach_cm",
+            "reach_missing",
             "stance",
             "wins",
             "losses",


### PR DESCRIPTION
## Summary
- Replace zero-filling in fighter preprocessing with `SimpleImputer` median strategy
- Track missing height, weight, and reach with new boolean columns
- Test imputation and missing-value indicators in preprocessing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9130e748c8324bfb900e9d415b5a4