### PR TITLE
Handle unknown future results in analysis utilities

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from ufc_predictor.analysis import aggregate_last_five_stats
+from ufc_predictor.analysis import aggregate_last_five_stats, get_next_5_results
 
 
 def test_aggregate_last_five_stats_missing_columns():
@@ -24,3 +24,29 @@ def test_aggregate_last_five_stats_tail_and_date_conversion():
     assert pd.api.types.is_datetime64_any_dtype(result["date"])
     assert result.loc[result["fighter"] == "A", "KD"].iloc[0] == pytest.approx(3.0)
     assert result.loc[result["fighter"] == "A", "date"].iloc[0] == pd.Timestamp("2020-01-06")
+
+
+def test_get_next_5_results_padding_and_mapping():
+    df = pd.DataFrame(
+        {
+            "fighter": ["A"] * 3,
+            "Winner": ["W", "L", "W"],
+        }
+    )
+
+    result = get_next_5_results(df)
+
+    assert list(result) == ["LWNNN", "WNNNN", "NNNNN"]
+
+
+def test_get_next_5_results_unexpected_values():
+    df = pd.DataFrame(
+        {
+            "fighter": ["A"] * 6,
+            "Winner": ["W", "X", "L", "D", None, "W"],
+        }
+    )
+
+    result = get_next_5_results(df)
+
+    assert list(result) == ["NLDNW", "LDNWN", "DNWNN", "NWNNN", "WNNNN", "NNNNN"]

--- a/ufc_predictor/analysis.py
+++ b/ufc_predictor/analysis.py
@@ -52,3 +52,48 @@ def aggregate_last_five_stats(df_fights: pd.DataFrame) -> pd.DataFrame:
     result = last_five.groupby("fighter", as_index=False).apply(_aggregate)
     result.reset_index(drop=True, inplace=True)
     return result
+
+
+def get_next_5_results(
+    df_fights: pd.DataFrame, fighter_col: str = "fighter", result_col: str = "Winner"
+) -> pd.Series:
+    """Return the outcomes of the next five fights for each row.
+
+    Parameters
+    ----------
+    df_fights:
+        DataFrame containing at least ``fighter_col`` and ``result_col``. The
+        DataFrame is assumed to be ordered chronologically for each fighter.
+    fighter_col:
+        Name of the column identifying the fighter.
+    result_col:
+        Name of the column with the bout result (e.g. ``"Winner"``).
+
+    Returns
+    -------
+    pandas.Series
+        Series aligned with ``df_fights`` where each entry is a string with the
+        results of the fighter's next five bouts. Results are encoded using
+        ``"W"`` for win, ``"L"`` for loss, ``"D"`` for draw and ``"N"`` for any
+        unexpected value or missing fight.
+    """
+
+    required = {fighter_col, result_col}
+    missing = required - set(df_fights.columns)
+    if missing:
+        raise ValueError(f"df_fights is missing required columns: {missing}")
+
+    mapping = {"W": "W", "L": "L", "D": "D"}
+    mapped = df_fights[result_col].map(lambda x: mapping.get(x, "N"))
+
+    next_results = pd.Series(index=df_fights.index, dtype=object)
+    temp = df_fights.assign(_mapped=mapped)
+    for _, group in temp.groupby(fighter_col):
+        results = group["_mapped"].tolist()
+        indices = group.index.tolist()
+        for i, idx in enumerate(indices):
+            future = results[i + 1 : i + 6]
+            padded = future + ["N"] * (5 - len(future))
+            next_results.loc[idx] = "".join(padded)
+
+    return next_results


### PR DESCRIPTION
## Summary
- add `get_next_5_results` to compute upcoming results per fighter
- map `Winner` values via dict with default `'N'`
- cover edge cases with unit tests for short series and unexpected inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9131f03a8832493430445b389dee7