### PR TITLE
Filter and normalize fight stats data

### DIFF
--- a/tests/test_fight_stats.py
+++ b/tests/test_fight_stats.py
@@ -2,6 +2,7 @@ import pandas as pd
 import runpy
 import pytest
 
+import ufc_predictor.fight_stats as fight_stats_module
 from ufc_predictor.fight_stats import compute_last_five_stats
 
 
@@ -26,3 +27,93 @@ def test_main_exits_when_no_data(monkeypatch, capsys):
     assert exc.value.code == 1
     captured = capsys.readouterr()
     assert "No stats generated; skipping export." in captured.out
+
+
+def test_filters_and_normalizes(tmp_path, monkeypatch):
+    data = pd.DataFrame(
+        {
+            "Fighter": ["F1", "F2", "F3", "F4"],
+            "Winner": ["W", "NC", "W", "D"],
+            "Method": [
+                "Decision - Unanimous",
+                "TKO - Doctor's Stoppage",
+                "TKO - Doctor's Stoppage",
+                "DQ",
+            ],
+            "Weight Class": [
+                "Bantamweight Bout",
+                "Featherweight Bout",
+                "Lightweight Bout",
+                "Heavyweight Bout",
+            ],
+            "KD": [0, 0, 0, 0],
+            "Sig. Str.": ["0 of 0"] * 4,
+            "Total Str.": ["0 of 0"] * 4,
+            "TD": ["0 of 0"] * 4,
+            "Sub. Att": [0, 0, 0, 0],
+            "Reversal": [0, 0, 0, 0],
+            "Control Time": ["0:00"] * 4,
+            "Head": ["0 of 0"] * 4,
+            "Body": ["0 of 0"] * 4,
+            "Leg": ["0 of 0"] * 4,
+            "Distance": ["0 of 0"] * 4,
+            "Clinch": ["0 of 0"] * 4,
+            "Ground": ["0 of 0"] * 4,
+            "Fight_lenght": ["0:01"] * 4,
+            "Format": ["3 Rnd"] * 4,
+        }
+    )
+    csv = tmp_path / "raw.csv"
+    data.to_csv(csv, index=False)
+
+    monkeypatch.setattr(fight_stats_module, "DATA_DIR", tmp_path)
+    df = compute_last_five_stats(csv)
+
+    assert len(df) == 2
+    assert set(df["Weight Class"]) == {"Bantamweight", "Lightweight"}
+    assert set(df["Method"]) == {"Decision", "KO/TKO"}
+    assert not set(df["Winner"]) & {"NC", "D"}
+
+
+def test_weight_class_regex_mapping(tmp_path, monkeypatch):
+    data = pd.DataFrame(
+        {
+            "Fighter": ["F1", "F2", "F3", "F4"],
+            "Winner": ["W"] * 4,
+            "Method": ["Decision - Majority"] * 4,
+            "Weight Class": [
+                "Road To UFC 1 Bantamweight Tournament Title Bout",
+                "UFC 10 Tournament Title Bout",
+                "UFC Women's Featherweight Title Bout",
+                "Catch Weight Bout",
+            ],
+            "KD": [0, 0, 0, 0],
+            "Sig. Str.": ["0 of 0"] * 4,
+            "Total Str.": ["0 of 0"] * 4,
+            "TD": ["0 of 0"] * 4,
+            "Sub. Att": [0, 0, 0, 0],
+            "Reversal": [0, 0, 0, 0],
+            "Control Time": ["0:00"] * 4,
+            "Head": ["0 of 0"] * 4,
+            "Body": ["0 of 0"] * 4,
+            "Leg": ["0 of 0"] * 4,
+            "Distance": ["0 of 0"] * 4,
+            "Clinch": ["0 of 0"] * 4,
+            "Ground": ["0 of 0"] * 4,
+            "Fight_lenght": ["0:01"] * 4,
+            "Format": ["3 Rnd"] * 4,
+        }
+    )
+    csv = tmp_path / "raw.csv"
+    data.to_csv(csv, index=False)
+
+    monkeypatch.setattr(fight_stats_module, "DATA_DIR", tmp_path)
+    df = compute_last_five_stats(csv)
+
+    assert len(df) == 4
+    assert set(df["Weight Class"]) == {
+        "Bantamweight",
+        "Openweight",
+        "Women's Featherweight",
+        "Catchweight",
+    }

--- a/ufc_predictor/fight_stats.py
+++ b/ufc_predictor/fight_stats.py
@@ -8,6 +8,32 @@ import numpy as np
 DATA_DIR = Path("data")
 
 
+# Regex-based mapping to collapse a variety of historical and tournament
+# weight-class labels into a canonical set. Patterns are evaluated in order so
+# that specific classes (e.g. ``Women's Flyweight``) take precedence over more
+# generic ones like ``Flyweight``.
+WEIGHT_CLASS_MAP = {
+    r".*Women's Bantamweight.*": "Women's Bantamweight",
+    r".*Women's Featherweight.*": "Women's Featherweight",
+    r".*Women's Flyweight.*": "Women's Flyweight",
+    r".*Women's Strawweight.*": "Women's Strawweight",
+    r".*(?<!Women's )Bantamweight.*": "Bantamweight",
+    r".*(?<!Women's )Featherweight.*": "Featherweight",
+    r".*(?<!Women's )Flyweight.*": "Flyweight",
+    r".*Light Heavyweight.*": "Light Heavyweight",
+    r".*Lightweight.*": "Lightweight",
+    r".*Middleweight.*": "Middleweight",
+    r".*Welterweight.*": "Welterweight",
+    r".*Super Heavyweight.*": "Super Heavyweight",
+    r".*Heavyweight.*": "Heavyweight",
+    r".*Catch Weight.*": "Catchweight",
+    r".*Open Weight.*": "Openweight",
+    r".*Tournament.*": "Openweight",
+    r".*Superfight.*": "Openweight",
+    r".*Grand Prix.*": "Openweight",
+}
+
+
 def _extract_numeric_pair(text: str) -> tuple[int, int]:
     """Return the landed and attempted values from strings like ``"20 of 53"``.
 
@@ -47,6 +73,17 @@ def compute_last_five_stats(csv_path: str | Path = DATA_DIR / "fight_stats_raw.c
     except FileNotFoundError:
         print(f"CSV file not found at {csv_path}")
         return pd.DataFrame()
+
+    df = df[~df["Winner"].isin(["NC", "D"]) & (df["Method"] != "DQ")]
+    df["Weight Class"] = df["Weight Class"].replace(WEIGHT_CLASS_MAP, regex=True)
+    df["Method"] = df["Method"].replace(
+        {
+            "Decision - Majority": "Decision",
+            "Decision - Split": "Decision",
+            "Decision - Unanimous": "Decision",
+            "TKO - Doctor's Stoppage": "KO/TKO",
+        }
+    )
 
     # Sequential date placeholder to preserve chronological order per fighter
     df["date"] = df.groupby("Fighter").cumcount()


### PR DESCRIPTION
## Summary
- remove no contest, draw and disqualification results when loading fight stats
- canonically map weight classes and fight methods
- add regression test for filtering and normalization
- expand weight-class mapping to handle tournament and title variations via regex

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9dd0893248324b32e1bb5ce84a0d5