### PR TITLE
Include fight metadata columns and filter 3/5 round bouts

### DIFF
--- a/app.py
+++ b/app.py
@@ -110,6 +110,7 @@ critical_cols = [
 missing_critical = [c for c in critical_cols if c not in columnas_X]
 if missing_critical:
     st.warning(f"Columnas no incluidas en columnas_X: {missing_critical}")
+    columnas_X.extend(missing_critical)
 
 # Título de la app
 st.title('Predicción de Resultados de Peleas de UFC')

--- a/ufc_predictor/fight_stats.py
+++ b/ufc_predictor/fight_stats.py
@@ -75,6 +75,11 @@ def compute_last_five_stats(csv_path: str | Path = DATA_DIR / "fight_stats_raw.c
         return pd.DataFrame()
 
     df = df[~df["Winner"].isin(["NC", "D"]) & (df["Method"] != "DQ")]
+    if "Format" in df.columns:
+        format_numeric = pd.to_numeric(
+            df["Format"].astype(str).str.extract(r"(\d+)")[0], errors="coerce"
+        )
+        df = df[format_numeric.isin([3, 5])].copy()
     df["Weight Class"] = df["Weight Class"].replace(WEIGHT_CLASS_MAP, regex=True)
     df["Method"] = df["Method"].replace(
         {

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -125,6 +125,14 @@ def train(
             ", ".join(faltantes),
         )
 
+    # Ensure essential bout metadata columns are always included when available
+    critical_cols = [
+        c for c in ["Rounds", "Format", "Weight Class"] if c in fight_stats.columns
+    ]
+    for col in critical_cols:
+        if col not in columnas_procesadas:
+            columnas_procesadas.append(col)
+
     if not columnas_procesadas:
         raise SystemExit("No se pudieron alinear columnas para entrenamiento")
 


### PR DESCRIPTION
## Summary
- Ensure `Rounds`, `Format`, and `Weight Class` are always used as features when present
- Automatically append missing critical columns in the Streamlit app
- Filter raw stats to only include bouts scheduled for three or five rounds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa0be760e483248e86a6b1b1a2d243