### PR TITLE
Show raw win probabilities in Streamlit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ El flujo de trabajo incluye desde el web scraping de datos de peleadores y comba
   - Predicción del método de victoria.
 - Aplicación web interactiva que permite al usuario cargar parámetros de un combate y obtener predicciones.
 
+## Diferencia de cálculo de probabilidades
+
+La aplicación ahora muestra las probabilidades de victoria generadas por el modelo sin normalizarlas por la suma de ambos peleadores. Para fines informativos también se presentan porcentajes normalizados, pero la determinación del ganador se basa en las probabilidades originales.
+
 ## Demo de la Aplicación
 
 La aplicación Streamlit está disponible públicamente en el siguiente enlace:

--- a/app.py
+++ b/app.py
@@ -233,18 +233,31 @@ else:
         proba_fighter_1 = pred_proba_fighter_1[0][1]  # Probabilidad de que fighter_1 gane
         proba_fighter_2 = pred_proba_fighter_2[0][1]  # Probabilidad de que fighter_2 gane
 
-        # Normalizar las probabilidades para que sumen 100% solo si el total es mayor a 0
+        st.write("\n--- Resultados de la Predicción del Ganador ---")
+        # Mostrar probabilidades sin normalizar
+        st.write(
+            f"{fighter_1}: {proba_fighter_1 * 100:.2f}% (sin normalizar)"
+        )
+        st.write(
+            f"{fighter_2}: {proba_fighter_2 * 100:.2f}% (sin normalizar)"
+        )
+
+        # Calcular versión normalizada sólo con fines informativos
         total = proba_fighter_1 + proba_fighter_2
         if total > 0:
-            proba_fighter_1_normalized = (proba_fighter_1 / total) * 100
-            proba_fighter_2_normalized = (proba_fighter_2 / total) * 100
-
-            st.write("\n--- Resultados de la Predicción del Ganador ---")
+            proba_fighter_1_normalized = proba_fighter_1 / total * 100
+            proba_fighter_2_normalized = proba_fighter_2 / total * 100
+            st.write("Probabilidades normalizadas:")
             st.write(f"{fighter_1}: {proba_fighter_1_normalized:.2f}%")
             st.write(f"{fighter_2}: {proba_fighter_2_normalized:.2f}%")
-            st.write(f"Predicción del ganador: {fighter_1 if proba_fighter_1_normalized > proba_fighter_2_normalized else fighter_2}")
         else:
-            st.error("Error: la suma de probabilidades es 0, se omite la normalización.")
+            st.error(
+                "Error: la suma de probabilidades es 0, se omite la normalización."
+            )
+
+        st.write(
+            f"Predicción del ganador: {fighter_1 if proba_fighter_1 > proba_fighter_2 else fighter_2}"
+        )
 
     # Función para hacer la predicción del método de pelea
     def hacer_prediccion_method(


### PR DESCRIPTION
## Summary
- Display raw win probabilities without normalizing them by the total
- Present normalized percentages only as additional info and adjust winner selection
- Document probability calculation changes in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb9d96c288324a95144d2451cc6f3