### PR TITLE
feat: allow manual round selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,8 +83,8 @@ if faltantes:
 # Replicar preprocesamiento utilizado durante el entrenamiento
 weight_class_mapping: dict[str, int] = {}
 if "Rounds" in fight_stats.columns:
-    fight_stats["Rounds"] = pd.to_numeric(
-        fight_stats["Rounds"], errors="coerce"
+    fight_stats["Rounds"] = (
+        fight_stats["Rounds"].astype(str).str.extract(r"(\d+)").astype(float)
     )
 if "Format" in fight_stats.columns:
     fight_stats["Format"] = (
@@ -181,9 +181,31 @@ else:
         index=weight_class_index,
     )
 
+    rounds_list = (
+        fight_stats["Rounds"].dropna().unique().tolist()
+        if "Rounds" in fight_stats.columns
+        else []
+    )
+    default_rounds = (
+        stats_fighter_1["Rounds"].iloc[0]
+        if "Rounds" in stats_fighter_1.columns
+        else (rounds_list[0] if rounds_list else None)
+    )
+    rounds_index = (
+        rounds_list.index(default_rounds)
+        if default_rounds in rounds_list
+        else 0
+    )
+    rounds_input = st.selectbox(
+        "Rondas:",
+        rounds_list,
+        index=rounds_index,
+    )
+
     # Mostrar valores calculados para transparencia
     st.write(f"Formato de la pelea: {format_input}")
     st.write(f"Clase de peso: {weight_class_label}")
+    st.write(f"Rondas: {rounds_input}")
     st.write(f"Forma últimos 5 de {fighter_1}: {form_last_5_fighter_1}")
     st.write(f"Forma últimos 5 de {fighter_2}: {form_last_5_fighter_2}")
 
@@ -199,12 +221,24 @@ else:
         format_input_code = (
             pd.Series([format_input])
             .astype(str)
-            .str.extract(r"(\d+)")
+            .str.extract(r"(\d+)", expand=False)
             .astype(float)
             .iloc[0]
         )
         stats_features_1["Format"] = format_input_code
         stats_features_2["Format"] = format_input_code
+    if "Rounds" in stats_features_1.columns:
+        stats_features_1["Rounds"] = format_input_code
+        stats_features_2["Rounds"] = format_input_code
+        rounds_input_code = (
+            pd.Series([rounds_input])
+            .astype(str)
+            .str.extract(r"(\d+)", expand=False)
+            .astype(float)
+            .iloc[0]
+        )
+        stats_features_1["Rounds"] = rounds_input_code
+        stats_features_2["Rounds"] = rounds_input_code
     if "Weight Class" in stats_features_1.columns:
         weight_class_input_code = weight_class_mapping[weight_class_label]
         stats_features_1["Weight Class"] = weight_class_input_code


### PR DESCRIPTION
## Summary
- parse rounds column using regex
- allow manual selection of rounds and apply to prediction features

## Testing
- `pytest -q`
- `python - <<'PY'
import pandas as pd, joblib
from ufc_predictor.config import MODEL_VERSION

stacking_winner = joblib.load(f"models/{MODEL_VERSION}/stacking_winner.pkl")

fight_stats = pd.read_csv('data/fight_stats.csv')
fight_stats['Rounds'] = fight_stats['Rounds'].astype(str).str.extract(r'(\\d+)').astype(float)
fight_stats['Format'] = fight_stats['Format'].astype(str).str.extract(r'(\\d+)').astype(float)
weight_class_cat = pd.Categorical(fight_stats['Weight Class'])
fight_stats['Weight Class'] = weight_class_cat.codes

columnas_X = pd.read_csv('data/columnas_X.csv', header=None).squeeze().tolist()
columnas_X = [c for c in columnas_X if c.lower() != 'win']

fighter_1, fighter_2 = fight_stats['Fighter'].unique()[:2]

sf1 = fight_stats[fight_stats['Fighter']==fighter_1].sort_values('date', ascending=False).head(1)
sf2 = fight_stats[fight_stats['Fighter']==fighter_2].sort_values('date', ascending=False).head(1)

feat1 = sf1[columnas_X].copy().drop(columns=['win'], errors='ignore')
feat2 = sf2[columnas_X].copy().drop(columns=['win'], errors='ignore')

feat1['Format'] = 5.0
feat2['Format'] = 5.0
wc_code = sf1['Weight Class'].iloc[0]
feat1['Weight Class'] = wc_code
feat2['Weight Class'] = wc_code

feat1 = feat1[columnas_X]
feat2 = feat2[columnas_X]

# Rounds = 5
feat1['Rounds'] = 5.0
feat2['Rounds'] = 5.0
pro1_5 = stacking_winner.predict_proba(feat1)[0][1]
pro2_5 = stacking_winner.predict_proba(feat2)[0][1]
print('Rounds set to', feat1['Rounds'].iloc[0], feat2['Rounds'].iloc[0])
print('Probabilities', pro1_5, pro2_5)

# Rounds = 3
feat1['Rounds'] = 3.0
feat2['Rounds'] = 3.0
pro1_3 = stacking_winner.predict_proba(feat1)[0][1]
pro2_3 = stacking_winner.predict_proba(feat2)[0][1]
print('Rounds changed to', feat1['Rounds'].iloc[0], feat2['Rounds'].iloc[0])
print('Probabilities', pro1_3, pro2_3)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68acc48622e483248ed07ac1cfa2bf03