### PR TITLE
Simplify rounds selection using format

### DIFF
--- a/app.py
+++ b/app.py
@@ -180,32 +180,9 @@ else:
         weight_class_list,
         index=weight_class_index,
     )
-
-    rounds_list = (
-        fight_stats["Rounds"].dropna().unique().tolist()
-        if "Rounds" in fight_stats.columns
-        else []
-    )
-    default_rounds = (
-        stats_fighter_1["Rounds"].iloc[0]
-        if "Rounds" in stats_fighter_1.columns
-        else (rounds_list[0] if rounds_list else None)
-    )
-    rounds_index = (
-        rounds_list.index(default_rounds)
-        if default_rounds in rounds_list
-        else 0
-    )
-    rounds_input = st.selectbox(
-        "Rondas:",
-        rounds_list,
-        index=rounds_index,
-    )
-
     # Mostrar valores calculados para transparencia
-    st.write(f"Formato de la pelea: {format_input}")
+    st.write(f"Formato/Rounds de la pelea: {format_input}")
     st.write(f"Clase de peso: {weight_class_label}")
-    st.write(f"Rondas: {rounds_input}")
     st.write(f"Forma últimos 5 de {fighter_1}: {form_last_5_fighter_1}")
     st.write(f"Forma últimos 5 de {fighter_2}: {form_last_5_fighter_2}")
 
@@ -217,7 +194,8 @@ else:
         st.error("La columna 'win' no debe estar presente en las características")
         st.stop()
     # Convertir entradas del usuario al mismo código utilizado en el entrenamiento
-    if "Format" in stats_features_1.columns:
+    # Parsear el formato seleccionado y asignarlo a las columnas correspondientes
+    if ("Format" in stats_features_1.columns) or ("Rounds" in stats_features_1.columns):
         format_input_code = (
             pd.Series([format_input])
             .astype(str)
@@ -225,20 +203,12 @@ else:
             .astype(float)
             .iloc[0]
         )
-        stats_features_1["Format"] = format_input_code
-        stats_features_2["Format"] = format_input_code
-    if "Rounds" in stats_features_1.columns:
-        stats_features_1["Rounds"] = format_input_code
-        stats_features_2["Rounds"] = format_input_code
-        rounds_input_code = (
-            pd.Series([rounds_input])
-            .astype(str)
-            .str.extract(r"(\d+)", expand=False)
-            .astype(float)
-            .iloc[0]
-        )
-        stats_features_1["Rounds"] = rounds_input_code
-        stats_features_2["Rounds"] = rounds_input_code
+        if "Format" in stats_features_1.columns:
+            stats_features_1["Format"] = format_input_code
+            stats_features_2["Format"] = format_input_code
+        if "Rounds" in stats_features_1.columns:
+            stats_features_1["Rounds"] = format_input_code
+            stats_features_2["Rounds"] = format_input_code
     if "Weight Class" in stats_features_1.columns:
         weight_class_input_code = weight_class_mapping[weight_class_label]
         stats_features_1["Weight Class"] = weight_class_input_code


### PR DESCRIPTION
## Summary
- Remove separate rounds selector and display format/rounds as a single option
- Fill both `Format` and `Rounds` feature columns from the numeric value of the selected format

## Testing
- `pytest`
- Manual check setting format to 5 rounds updates `Rounds` column to 5

------
https://chatgpt.com/codex/tasks/task_e_68ad303e336c83249830d42dff9e8156