### PR TITLE
feat: support extended hyperparameter search

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ versión se centraliza en `ufc_predictor/config.py`.
 Antes de ejecutar estos scripts, asegúrate de que el archivo `data/fight_stats.csv` exista,
 ya que contiene las características utilizadas para el entrenamiento.
 
+Puedes ajustar el comportamiento mediante variables de entorno:
+
+- `MODEL_NAMES`: lista separada por comas de modelos a entrenar.
+- `FAST_MODE=1`: usa un subconjunto de datos y grids mínimos para ejecuciones rápidas.
+- `EXTENDED_SEARCH=1`: activa grids de hiperparámetros más amplios para una búsqueda exhaustiva.
+  Si ambos flags se usan, `FAST_MODE` tiene prioridad.
+
 Para entrenar el modelo del método de victoria:
 
 ```bash
@@ -107,8 +114,8 @@ Para acelerar la integración continua, los grids de hiperparámetros en
 `ufc_predictor/train.py` usan valores reducidos.  Por ejemplo,
 `n_estimators` se limita a `[50, 100]`, `max_depth` a `[3, 5]` y
 `learning_rate` queda fijo en `0.1`, lo que implica menos de 50 "fits" por
-modelo con validación cruzada de 3 pliegues.  Realiza la búsqueda completa
-fuera del entorno de CI ampliando estas combinaciones.
+modelo con validación cruzada de 3 pliegues.  Fuera del entorno de CI puedes
+activar `EXTENDED_SEARCH=1` para ampliar estas combinaciones.
 
 ## 📊 Agregación vs Dataset Rolling
 

--- a/entrenamiento.py
+++ b/entrenamiento.py
@@ -5,4 +5,6 @@ from ufc_predictor.train import train
 if __name__ == "__main__":
     model_names = os.getenv("MODEL_NAMES")
     nombres = [m.strip() for m in model_names.split(",") if m.strip()] if model_names else None
-    train("Method", model_names=nombres)
+    fast = os.getenv("FAST_MODE", "").lower() in ("1", "true", "yes")
+    extended = os.getenv("EXTENDED_SEARCH", "").lower() in ("1", "true", "yes")
+    train("Method", model_names=nombres, fast_mode=fast, extended_search=extended)

--- a/entrenamiento_winner.py
+++ b/entrenamiento_winner.py
@@ -6,4 +6,6 @@ from ufc_predictor.train import train
 if __name__ == "__main__":
     model_names = os.getenv("MODEL_NAMES")
     nombres = [m.strip() for m in model_names.split(",") if m.strip()] if model_names else None
-    train("Winner", model_names=nombres)
+    fast = os.getenv("FAST_MODE", "").lower() in ("1", "true", "yes")
+    extended = os.getenv("EXTENDED_SEARCH", "").lower() in ("1", "true", "yes")
+    train("Winner", model_names=nombres, fast_mode=fast, extended_search=extended)

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -73,3 +73,34 @@ def test_train_split_deterministic(tmp_path, monkeypatch):
     pd.testing.assert_series_equal(y_train1, y_train2)
     pd.testing.assert_series_equal(y_test1, y_test2)
 
+
+def test_extended_search_expands_params(tmp_path, monkeypatch):
+    X = pd.DataFrame({"feat": range(12)})
+    y = ["W", "L"] * 6
+
+    fight_stats = X.assign(Winner=y, Method="KO")
+    fight_stats.to_csv(tmp_path / "fight_stats.csv", index=False)
+    pd.Series(["feat"]).to_csv(tmp_path / "columnas_X.csv", index=False, header=False)
+
+    captured: dict = {}
+
+    def capture_grid(estimator, params, *args, **kwargs):
+        captured["params"] = params
+        return DummyGridSearchCV(estimator, *args, **kwargs)
+
+    monkeypatch.setattr(train_module.joblib, "dump", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_module, "GridSearchCV", capture_grid)
+    monkeypatch.setattr(train_module, "StackingClassifier", DummyStackingClassifier)
+
+    train(
+        "Winner",
+        data_dir=str(tmp_path),
+        models_dir=str(tmp_path),
+        model_names=["LogisticRegression"],
+        extended_search=True,
+    )
+
+    assert len(captured["params"]["C"]) > 3
+    assert 0.01 in captured["params"]["C"]
+    assert 100 in captured["params"]["C"]
+

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -35,6 +35,7 @@ def train(
     models: dict | None = None,
     model_names: list[str] | None = None,
     fast_mode: bool = False,
+    extended_search: bool = False,
 ) -> None:
     """Entrena modelos base y un stacking final para ``target_column``.
 
@@ -60,6 +61,9 @@ def train(
         ejecuciones rápidas: solo se entrenan modelos livianos con un
         único conjunto de hiperparámetros, se usa una fracción pequeña de
         los datos y la validación cruzada utiliza dos particiones.
+    extended_search:
+        Activa grids de hiperparámetros más amplios para una búsqueda más
+        exhaustiva a costa de mayor tiempo de entrenamiento.
 
     Notes
     -----
@@ -197,56 +201,111 @@ def train(
             from xgboost import XGBClassifier
             from catboost import CatBoostClassifier
 
-            # Hyperparameter grids are intentionally small to keep CI runtime low.  With
-            # ``n_splits=3`` the largest grid below yields <50 fits.  For thorough
-            # experiments, expand these ranges offline (e.g. include more
-            # ``learning_rate`` values or deeper ``max_depth``).
-            models = {
-                "XGBoost": (
-                    XGBClassifier(random_state=RANDOM_STATE),
-                    {
-                        "learning_rate": [0.1],
-                        "n_estimators": [50, 100],
-                        "max_depth": [3, 5],
-                    },
-                ),
-                "LightGBM": (
-                    LGBMClassifier(random_state=RANDOM_STATE),
-                    {
-                        "learning_rate": [0.1],
-                        "n_estimators": [50, 100],
-                        "max_depth": [3, 5],
-                    },
-                ),
-                "CatBoost": (
-                    CatBoostClassifier(verbose=0, random_state=RANDOM_STATE),
-                    {"learning_rate": [0.1], "iterations": [50, 100]},
-                ),
-                "RandomForest": (
-                    RandomForestClassifier(random_state=RANDOM_STATE),
-                    {
-                        "n_estimators": [50, 100],
-                        "max_depth": [10, 20],
-                        "min_samples_split": [2, 5],
-                    },
-                ),
-                "GradientBoosting": (
-                    GradientBoostingClassifier(random_state=RANDOM_STATE),
-                    {
-                        "learning_rate": [0.1],
-                        "n_estimators": [50, 100],
-                        "max_depth": [3, 5],
-                    },
-                ),
-                "LogisticRegression": (
-                    LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
-                    {"C": [0.1, 1, 10], "solver": ["lbfgs", "liblinear"]},
-                ),
-                "SVC": (
-                    SVC(probability=True, random_state=RANDOM_STATE),
-                    {"C": [0.1, 1, 10], "kernel": ["linear", "rbf"]},
-                ),
-            }
+            if extended_search:
+                models = {
+                    "XGBoost": (
+                        XGBClassifier(random_state=RANDOM_STATE),
+                        {
+                            "learning_rate": [0.05, 0.1, 0.2],
+                            "n_estimators": [50, 100, 200],
+                            "max_depth": [3, 5, 7],
+                        },
+                    ),
+                    "LightGBM": (
+                        LGBMClassifier(random_state=RANDOM_STATE),
+                        {
+                            "learning_rate": [0.05, 0.1, 0.2],
+                            "n_estimators": [50, 100, 200],
+                            "max_depth": [3, 5, 7],
+                        },
+                    ),
+                    "CatBoost": (
+                        CatBoostClassifier(verbose=0, random_state=RANDOM_STATE),
+                        {
+                            "learning_rate": [0.01, 0.1],
+                            "iterations": [50, 100, 200],
+                        },
+                    ),
+                    "RandomForest": (
+                        RandomForestClassifier(random_state=RANDOM_STATE),
+                        {
+                            "n_estimators": [100, 200, 300],
+                            "max_depth": [None, 10, 20, 30],
+                            "min_samples_split": [2, 5, 10],
+                        },
+                    ),
+                    "GradientBoosting": (
+                        GradientBoostingClassifier(random_state=RANDOM_STATE),
+                        {
+                            "learning_rate": [0.05, 0.1],
+                            "n_estimators": [100, 200],
+                            "max_depth": [3, 5, 7],
+                        },
+                    ),
+                    "LogisticRegression": (
+                        LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
+                        {
+                            "C": [0.01, 0.1, 1, 10, 100],
+                            "solver": ["lbfgs", "liblinear"],
+                        },
+                    ),
+                    "SVC": (
+                        SVC(probability=True, random_state=RANDOM_STATE),
+                        {
+                            "C": [0.1, 1, 10, 100],
+                            "kernel": ["linear", "rbf", "poly"],
+                        },
+                    ),
+                }
+            else:
+                # Hyperparameter grids are intentionally small to keep CI runtime low.
+                # Con ``n_splits=3`` el grid más grande genera <50 ajustes.
+                models = {
+                    "XGBoost": (
+                        XGBClassifier(random_state=RANDOM_STATE),
+                        {
+                            "learning_rate": [0.1],
+                            "n_estimators": [50, 100],
+                            "max_depth": [3, 5],
+                        },
+                    ),
+                    "LightGBM": (
+                        LGBMClassifier(random_state=RANDOM_STATE),
+                        {
+                            "learning_rate": [0.1],
+                            "n_estimators": [50, 100],
+                            "max_depth": [3, 5],
+                        },
+                    ),
+                    "CatBoost": (
+                        CatBoostClassifier(verbose=0, random_state=RANDOM_STATE),
+                        {"learning_rate": [0.1], "iterations": [50, 100]},
+                    ),
+                    "RandomForest": (
+                        RandomForestClassifier(random_state=RANDOM_STATE),
+                        {
+                            "n_estimators": [50, 100],
+                            "max_depth": [10, 20],
+                            "min_samples_split": [2, 5],
+                        },
+                    ),
+                    "GradientBoosting": (
+                        GradientBoostingClassifier(random_state=RANDOM_STATE),
+                        {
+                            "learning_rate": [0.1],
+                            "n_estimators": [50, 100],
+                            "max_depth": [3, 5],
+                        },
+                    ),
+                    "LogisticRegression": (
+                        LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
+                        {"C": [0.1, 1, 10], "solver": ["lbfgs", "liblinear"]},
+                    ),
+                    "SVC": (
+                        SVC(probability=True, random_state=RANDOM_STATE),
+                        {"C": [0.1, 1, 10], "kernel": ["linear", "rbf"]},
+                    ),
+                }
 
     if model_names:
         nombres = {n.lower() for n in model_names}


### PR DESCRIPTION
## Summary
- allow optional extended hyperparameter grids in `train`
- expose `FAST_MODE` and `EXTENDED_SEARCH` env vars in training scripts
- document new flags and add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad357ab01083249d27ad2d226175c6