### PR TITLE
Allow configuring cross-validation splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Puedes ajustar el comportamiento mediante variables de entorno:
 - `FAST_MODE=1`: usa un subconjunto de datos y grids mínimos para ejecuciones rápidas.
 - `EXTENDED_SEARCH=1`: activa grids de hiperparámetros más amplios para una búsqueda exhaustiva.
   Si ambos flags se usan, `FAST_MODE` tiene prioridad.
+- `CV_SPLITS`: número de pliegues para la validación cruzada (por defecto, `3`).
+  También puedes establecerlo desde la línea de comandos con `--cv-splits`.
 
 Para entrenar el modelo del método de victoria:
 

--- a/entrenamiento.py
+++ b/entrenamiento.py
@@ -1,10 +1,27 @@
+import argparse
 import os
 
 from ufc_predictor.train import train
 
+
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--cv-splits", type=int, default=None, help="Número de pliegues de validación cruzada"
+    )
+    args = parser.parse_args()
+
     model_names = os.getenv("MODEL_NAMES")
     nombres = [m.strip() for m in model_names.split(",") if m.strip()] if model_names else None
     fast = os.getenv("FAST_MODE", "").lower() in ("1", "true", "yes")
     extended = os.getenv("EXTENDED_SEARCH", "").lower() in ("1", "true", "yes")
-    train("Method", model_names=nombres, fast_mode=fast, extended_search=extended)
+    cv_env = os.getenv("CV_SPLITS")
+    cv_splits = int(cv_env) if cv_env else (args.cv_splits or 3)
+
+    train(
+        "Method",
+        model_names=nombres,
+        fast_mode=fast,
+        extended_search=extended,
+        cv_splits=cv_splits,
+    )

--- a/entrenamiento_winner.py
+++ b/entrenamiento_winner.py
@@ -1,11 +1,28 @@
 
+import argparse
 import os
 
 from ufc_predictor.train import train
 
+
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--cv-splits", type=int, default=None, help="Número de pliegues de validación cruzada"
+    )
+    args = parser.parse_args()
+
     model_names = os.getenv("MODEL_NAMES")
     nombres = [m.strip() for m in model_names.split(",") if m.strip()] if model_names else None
     fast = os.getenv("FAST_MODE", "").lower() in ("1", "true", "yes")
     extended = os.getenv("EXTENDED_SEARCH", "").lower() in ("1", "true", "yes")
-    train("Winner", model_names=nombres, fast_mode=fast, extended_search=extended)
+    cv_env = os.getenv("CV_SPLITS")
+    cv_splits = int(cv_env) if cv_env else (args.cv_splits or 3)
+
+    train(
+        "Winner",
+        model_names=nombres,
+        fast_mode=fast,
+        extended_search=extended,
+        cv_splits=cv_splits,
+    )

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -104,3 +104,36 @@ def test_extended_search_expands_params(tmp_path, monkeypatch):
     assert 0.01 in captured["params"]["C"]
     assert 100 in captured["params"]["C"]
 
+
+def test_cv_splits_respected(tmp_path, monkeypatch):
+    X = pd.DataFrame({"feat": range(12)})
+    y = ["W", "L"] * 6
+
+    fight_stats = X.assign(Winner=y, Method="KO")
+    fight_stats.to_csv(tmp_path / "fight_stats.csv", index=False)
+    pd.Series(["feat"]).to_csv(tmp_path / "columnas_X.csv", index=False, header=False)
+
+    models = {"LogReg": (LogisticRegression(random_state=train_module.RANDOM_STATE), {})}
+
+    monkeypatch.setattr(train_module.joblib, "dump", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_module, "GridSearchCV", DummyGridSearchCV)
+    monkeypatch.setattr(train_module, "StackingClassifier", DummyStackingClassifier)
+
+    captured = {}
+
+    class DummyStratifiedKFold:
+        def __init__(self, n_splits, *args, **kwargs):
+            captured["n_splits"] = n_splits
+
+    monkeypatch.setattr(train_module, "StratifiedKFold", DummyStratifiedKFold)
+
+    train(
+        "Winner",
+        data_dir=str(tmp_path),
+        models_dir=str(tmp_path),
+        models=models,
+        cv_splits=5,
+    )
+
+    assert captured["n_splits"] == 5
+

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -36,6 +36,7 @@ def train(
     model_names: list[str] | None = None,
     fast_mode: bool = False,
     extended_search: bool = False,
+    cv_splits: int = 3,
 ) -> None:
     """Entrena modelos base y un stacking final para ``target_column``.
 
@@ -64,11 +65,14 @@ def train(
     extended_search:
         Activa grids de hiperparámetros más amplios para una búsqueda más
         exhaustiva a costa de mayor tiempo de entrenamiento.
+    cv_splits:
+        Número de particiones para la validación cruzada cuando ``fast_mode``
+        está desactivado. El valor efectivo será ``min(cv_splits, min_clase)``.
 
     Notes
     -----
-    Se requiere al menos ``min(3, min_clase)`` muestras por clase para la
-    validación estratificada (``min(2, min_clase)`` si se activa
+    Se requiere al menos ``min(cv_splits, min_clase)`` muestras por clase para
+    la validación estratificada (``min(2, min_clase)`` si se activa
     ``fast_mode``) donde ``min_clase`` es la cantidad mínima de ejemplos por
     clase en ``y``. Si alguna clase tiene menos ejemplos, aumenta los datos de
     entrenamiento.
@@ -316,7 +320,7 @@ def train(
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, random_state=RANDOM_STATE
     )
-    n_splits = min(2 if fast_mode else 3, min_clase)
+    n_splits = min(cv_splits if not fast_mode else 2, min_clase)
     # Se requieren al menos ``n_splits`` muestras por clase o debes aumentar los datos.
     cv = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=RANDOM_STATE)
     mejores = []


### PR DESCRIPTION
## Summary
- expose configurable `cv_splits` parameter in `train` for flexible StratifiedKFold setup
- allow passing CV splits via `--cv-splits`/`CV_SPLITS` in training scripts
- document new option and cover it with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae00b8fd488324ad4b9a2ef8a71fb6