### PR TITLE
feat: allow overriding model grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ Puedes ajustar el comportamiento mediante variables de entorno:
 - `EXTENDED_SEARCH=1`: activa grids de hiperparámetros más amplios para una búsqueda exhaustiva.
   Si ambos flags se usan, `FAST_MODE` tiene prioridad.
 
+Opcionalmente puedes suministrar un archivo JSON o YAML con ajustes de
+hiperparámetros por modelo. Pásalo como primer argumento al script y sus
+valores se combinarán con los grids por defecto. Ejemplo:
+
+```json
+// grid.json
+{
+  "RandomForest": {"n_estimators": [150, 200]},
+  "LogisticRegression": {"C": [0.5, 2.0]}
+}
+```
+
+```bash
+python entrenamiento.py grid.json
+```
+
 Para entrenar el modelo del método de victoria:
 
 ```bash

--- a/entrenamiento.py
+++ b/entrenamiento.py
@@ -1,10 +1,34 @@
+import json
 import os
+import sys
 
 from ufc_predictor.train import train
 
+
+def _load_overrides(path: str) -> dict:
+    if path.lower().endswith((".yml", ".yaml")):
+        try:
+            import yaml
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise SystemExit("PyYAML es requerido para archivos YAML") from exc
+        with open(path) as f:
+            return yaml.safe_load(f)
+    with open(path) as f:
+        return json.load(f)
+
+
 if __name__ == "__main__":
+    grid_path = sys.argv[1] if len(sys.argv) > 1 else None
+    overrides = _load_overrides(grid_path) if grid_path else None
+
     model_names = os.getenv("MODEL_NAMES")
     nombres = [m.strip() for m in model_names.split(",") if m.strip()] if model_names else None
     fast = os.getenv("FAST_MODE", "").lower() in ("1", "true", "yes")
     extended = os.getenv("EXTENDED_SEARCH", "").lower() in ("1", "true", "yes")
-    train("Method", model_names=nombres, fast_mode=fast, extended_search=extended)
+    train(
+        "Method",
+        model_names=nombres,
+        fast_mode=fast,
+        extended_search=extended,
+        grid_overrides=overrides,
+    )

--- a/entrenamiento_winner.py
+++ b/entrenamiento_winner.py
@@ -1,11 +1,35 @@
 
+import json
 import os
+import sys
 
 from ufc_predictor.train import train
 
+
+def _load_overrides(path: str) -> dict:
+    if path.lower().endswith((".yml", ".yaml")):
+        try:
+            import yaml
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise SystemExit("PyYAML es requerido para archivos YAML") from exc
+        with open(path) as f:
+            return yaml.safe_load(f)
+    with open(path) as f:
+        return json.load(f)
+
+
 if __name__ == "__main__":
+    grid_path = sys.argv[1] if len(sys.argv) > 1 else None
+    overrides = _load_overrides(grid_path) if grid_path else None
+
     model_names = os.getenv("MODEL_NAMES")
     nombres = [m.strip() for m in model_names.split(",") if m.strip()] if model_names else None
     fast = os.getenv("FAST_MODE", "").lower() in ("1", "true", "yes")
     extended = os.getenv("EXTENDED_SEARCH", "").lower() in ("1", "true", "yes")
-    train("Winner", model_names=nombres, fast_mode=fast, extended_search=extended)
+    train(
+        "Winner",
+        model_names=nombres,
+        fast_mode=fast,
+        extended_search=extended,
+        grid_overrides=overrides,
+    )

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -104,3 +104,34 @@ def test_extended_search_expands_params(tmp_path, monkeypatch):
     assert 0.01 in captured["params"]["C"]
     assert 100 in captured["params"]["C"]
 
+
+def test_grid_overrides_extend_defaults(tmp_path, monkeypatch):
+    X = pd.DataFrame({"feat": range(12)})
+    y = ["W", "L"] * 6
+
+    fight_stats = X.assign(Winner=y, Method="KO")
+    fight_stats.to_csv(tmp_path / "fight_stats.csv", index=False)
+    pd.Series(["feat"]).to_csv(tmp_path / "columnas_X.csv", index=False, header=False)
+
+    captured: dict = {}
+
+    def capture_grid(estimator, params, *args, **kwargs):
+        captured["params"] = params
+        return DummyGridSearchCV(estimator, *args, **kwargs)
+
+    monkeypatch.setattr(train_module.joblib, "dump", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_module, "GridSearchCV", capture_grid)
+    monkeypatch.setattr(train_module, "StackingClassifier", DummyStackingClassifier)
+
+    overrides = {"LogisticRegression": {"C": [5], "penalty": ["l1"]}}
+    train(
+        "Winner",
+        data_dir=str(tmp_path),
+        models_dir=str(tmp_path),
+        model_names=["LogisticRegression"],
+        grid_overrides=overrides,
+    )
+
+    assert set(captured["params"]["C"]) == {0.1, 1, 10, 5}
+    assert captured["params"]["penalty"] == ["l1"]
+

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -28,6 +28,22 @@ RANDOM_STATE = 42
 DATA_DIR = os.path.abspath("data")
 
 
+def _merge_params(base: dict, overrides: dict) -> dict:
+    """Merge hyperparameter grids, extending or replacing existing values."""
+
+    def _to_list(value):
+        return list(value) if isinstance(value, (list, tuple)) else [value]
+
+    merged = {k: _to_list(v) for k, v in base.items()}
+    for param, values in overrides.items():
+        vals = _to_list(values)
+        if param in merged:
+            merged[param].extend(v for v in vals if v not in merged[param])
+        else:
+            merged[param] = vals
+    return merged
+
+
 def train(
     target_column: str,
     data_dir: str = DATA_DIR,
@@ -36,6 +52,7 @@ def train(
     model_names: list[str] | None = None,
     fast_mode: bool = False,
     extended_search: bool = False,
+    grid_overrides: dict | None = None,
 ) -> None:
     """Entrena modelos base y un stacking final para ``target_column``.
 
@@ -64,6 +81,11 @@ def train(
     extended_search:
         Activa grids de hiperparámetros más amplios para una búsqueda más
         exhaustiva a costa de mayor tiempo de entrenamiento.
+    grid_overrides:
+        Diccionario con hiperparámetros adicionales por modelo. Las claves
+        deben coincidir con las del diccionario ``models`` y sus valores se
+        combinan con los grids por defecto, sustituyendo o ampliando los
+        existentes.
 
     Notes
     -----
@@ -312,6 +334,12 @@ def train(
         models = {k: v for k, v in models.items() if k.lower() in nombres}
         if not models:
             raise SystemExit("No se encontraron modelos válidos en model_names")
+
+    if grid_overrides:
+        for nombre, override in grid_overrides.items():
+            if nombre in models:
+                modelo, params = models[nombre]
+                models[nombre] = (modelo, _merge_params(params, override))
 
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, random_state=RANDOM_STATE


### PR DESCRIPTION
## Summary
- allow passing per-model grid overrides and merge with default grids
- enable training scripts to load JSON or YAML grid configs
- document grid override usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae00b575308324bad76ae8a5712f83