### PR TITLE
Import json for overrides loader in training scripts

### DIFF
--- a/entrenamiento.py
+++ b/entrenamiento.py
@@ -1,4 +1,5 @@
 
+import json
 import os
 import sys
 

--- a/entrenamiento_winner.py
+++ b/entrenamiento_winner.py
@@ -1,4 +1,5 @@
 
+import json
 import os
 import sys
 
@@ -34,4 +35,4 @@ if __name__ == "__main__":
         model_names=nombres,
         fast_mode=fast,
         extended_search=extended,
-
+    )

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -52,7 +52,8 @@ def train(
     model_names: list[str] | None = None,
     fast_mode: bool = False,
     extended_search: bool = False,
-
+    grid_overrides: dict | None = None,
+) -> None:
     """Entrena modelos base y un stacking final para ``target_column``.
 
     Parameters


### PR DESCRIPTION
## Summary
- import json in entrenamiento and entrenamiento_winner scripts to support JSON override files
- fix train function signature with grid_overrides parameter

## Testing
- `python - <<'PY'
import json
from entrenamiento import _load_overrides as load_method
from entrenamiento_winner import _load_overrides as load_winner
with open('overrides.json', 'w') as f:
    json.dump({'x': 1}, f)
print(load_method('overrides.json'))
print(load_winner('overrides.json'))
PY`
- `pytest -q` *(fails: SyntaxError in tests/test_train_model.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ae05487fb483249454afe659925e7b