### PR TITLE
Add grid overrides and CV options to train pipeline

### DIFF
--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -52,7 +52,10 @@ def train(
     model_names: list[str] | None = None,
     fast_mode: bool = False,
     extended_search: bool = False,
-
+    grid_overrides: dict | None = None,
+    cv_splits: int = 5,
+    final_estimator: LogisticRegression = LogisticRegression(),
+):
     """Entrena modelos base y un stacking final para ``target_column``.
 
     Parameters
@@ -85,7 +88,12 @@ def train(
         deben coincidir con las del diccionario ``models`` y sus valores se
         combinan con los grids por defecto, sustituyendo o ampliando los
         existentes.
-
+    cv_splits:
+        Número de particiones para la validación cruzada (se reduce a 2 si
+        ``fast_mode`` es ``True``).
+    final_estimator:
+        Estimador final del stacking. Por defecto se utiliza
+        ``LogisticRegression()``.
 
     Notes
     -----


### PR DESCRIPTION
## Summary
- extend training function with `grid_overrides`, `cv_splits` and a configurable `final_estimator`
- document new arguments and place the docstring after function definition

## Testing
- `python -m py_compile ufc_predictor/train.py`
- `pytest -q` *(fails: SyntaxError in tests/test_train_model.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ae054b9f548324b796306db418c756