### PR TITLE
Return stacking model from training helper

### DIFF
--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -397,3 +397,5 @@ def train(
         f.write(f"Accuracy: {accuracy:.4f}\n")
         f.write(f"ROC-AUC: {roc_auc:.4f}\n")
         f.write(f"Random state: {RANDOM_STATE}\n")
+
+    return stacking


### PR DESCRIPTION
## Summary
- ensure `train` returns the fitted stacking classifier after writing metrics

## Testing
- `python entrenamiento.py` *(interrupted after start)*
- `pytest -q` *(fails: SyntaxError in tests/test_train_model.py: '(' was never closed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0ba3100483248713eb4189c88b41