### PR TITLE
Handle missing values in training

### DIFF
--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -104,19 +104,3 @@ def test_extended_search_expands_params(tmp_path, monkeypatch):
     assert len(captured["params"]["C"]) > 3
     assert 0.01 in captured["params"]["C"]
     assert 100 in captured["params"]["C"]
-
-
-
-    X = pd.DataFrame({"feat": range(12)})
-    y = ["W", "L"] * 6
-
-    fight_stats = X.assign(Winner=y, Method="KO")
-    fight_stats.to_csv(tmp_path / "fight_stats.csv", index=False)
-    pd.Series(["feat"]).to_csv(tmp_path / "columnas_X.csv", index=False, header=False)
-
-    train(
-        "Winner",
-        data_dir=str(tmp_path),
-        models_dir=str(tmp_path),
-
-

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -18,6 +18,7 @@ from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier,
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score, roc_auc_score
 from sklearn.model_selection import GridSearchCV, StratifiedKFold, train_test_split
+from sklearn.impute import SimpleImputer
 from sklearn.svm import SVC
 from sklearn.preprocessing import LabelEncoder
 
@@ -193,6 +194,20 @@ def train(
         )
         X = X.drop(columns=no_numericas)
         columnas_procesadas = [c for c in columnas_procesadas if c not in no_numericas]
+
+    # Elimina columnas completamente vacías e imputa el resto
+    vacias = X.columns[X.isna().all()].tolist()
+    if vacias:
+        print(
+            "⚠️ Las siguientes columnas no contienen datos y se descartarán:",
+            ", ".join(vacias),
+        )
+        X = X.drop(columns=vacias)
+        columnas_procesadas = [c for c in columnas_procesadas if c not in vacias]
+
+    if X.isna().any().any():
+        imputer = SimpleImputer(strategy="mean")
+        X = pd.DataFrame(imputer.fit_transform(X), columns=X.columns, index=X.index)
 
     y = fight_stats[target_column]
     encoder = LabelEncoder()


### PR DESCRIPTION
## Summary
- Drop empty numeric columns and impute remaining NaN values with mean during feature preparation
- Remove stray code from tests/test_train_model.py to fix syntax error in test suite

## Testing
- `python - <<'PY'
from ufc_predictor.train import train
train('Winner', fast_mode=True)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1932230083249322147138682797