### PR TITLE
Guardar mispredicciones y documentar uso

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ Para entrenar el modelo del ganador del combate:
 python entrenamiento_winner.py
 ```
 
+Tras cada entrenamiento se genera `data/mispredictions_{target}.csv` con las filas
+del dataset original que el modelo predijo de forma incorrecta. Revisa este
+archivo para detectar registros erróneos o columnas mal procesadas; corrige esos
+datos en `fight_stats.csv` o ajusta tu preprocesamiento antes de reentrenar.
+
 ### Ajustes rápidos en CI
 
 Para acelerar la integración continua, los grids de hiperparámetros en

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -124,6 +124,10 @@ def train(
         & (fight_stats["Method"] != "DQ")  # Excluir peleas terminadas por descalificación
     ]
 
+    # Conservar una copia con todas las columnas originales para analizar
+    # posteriormente los casos mal clasificados.
+    fight_stats_original = fight_stats.copy()
+
     try:
         columnas_X = pd.read_csv(
             os.path.join(data_dir, "columnas_X.csv"), header=None
@@ -401,6 +405,13 @@ def train(
 
     y_pred = stacking.predict(X_test)
     y_proba = stacking.predict_proba(X_test)
+
+    # Guardar filas donde el modelo se equivocó para su análisis posterior
+    mis_idx = y_test.index[y_pred != y_test]
+    mispredictions = fight_stats_original.loc[mis_idx]
+    mispredictions.to_csv(
+        os.path.join(data_dir, f"mispredictions_{target_suffix}.csv"), index=False
+    )
 
     accuracy = accuracy_score(y_test, y_pred)
     if len(set(y_test)) == 2:


### PR DESCRIPTION
## Summary
- Conserve una copia de las filas originales y guárdalas cuando el modelo se equivoca
- Documenta cómo revisar mispredicciones para depurar el dataset antes de reentrenar

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0dc1dfb288324ab6bf266e29171b2