### PR TITLE
feat: allow stacking passthrough and meta-model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,22 @@ Puedes ajustar el comportamiento mediante variables de entorno:
 - `EXTENDED_SEARCH=1`: activa grids de hiperparámetros más amplios para una búsqueda exhaustiva.
   Si ambos flags se usan, `FAST_MODE` tiene prioridad.
 
+### Configurar el meta-modelo
 
+El stacking final utiliza por defecto una regresión logística definida en
+`ufc_predictor/config.py` como `STACKING_FINAL_ESTIMATOR`. Puedes cambiar este
+valor en la configuración o pasar cualquier estimador compatible mediante el
+argumento `final_estimator` de `train`. Además, el parámetro `passthrough`
+permite concatenar las características originales con las predicciones de los
+modelos base al entrenar el meta-modelo.
+
+```python
+from sklearn.ensemble import GradientBoostingClassifier
+from ufc_predictor.train import train
+
+# Usa GradientBoosting como meta-modelo y activa passthrough
+train("Winner", final_estimator=GradientBoostingClassifier(), passthrough=True)
+```
 
 Para entrenar el modelo del método de victoria:
 

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -104,3 +104,48 @@ def test_extended_search_expands_params(tmp_path, monkeypatch):
     assert len(captured["params"]["C"]) > 3
     assert 0.01 in captured["params"]["C"]
     assert 100 in captured["params"]["C"]
+
+
+def test_passthrough_and_final_estimator(tmp_path, monkeypatch):
+    X = pd.DataFrame({"feat": range(12)})
+    y = ["W", "L"] * 6
+
+    fight_stats = X.assign(Winner=y, Method="KO")
+    fight_stats.to_csv(tmp_path / "fight_stats.csv", index=False)
+    pd.Series(["feat"]).to_csv(tmp_path / "columnas_X.csv", index=False, header=False)
+
+    captured: dict = {}
+
+    class CaptureStacking(DummyStackingClassifier):
+        def __init__(self, *args, **kwargs):
+            captured["passthrough"] = kwargs.get("passthrough")
+            captured["final_estimator"] = kwargs.get("final_estimator")
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(train_module.joblib, "dump", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_module, "GridSearchCV", DummyGridSearchCV)
+    monkeypatch.setattr(train_module, "StackingClassifier", CaptureStacking)
+
+    monkeypatch.setattr(
+        train_module,
+        "STACKING_FINAL_ESTIMATOR",
+        GradientBoostingClassifier(),
+    )
+
+    models = {"LogReg": (LogisticRegression(random_state=train_module.RANDOM_STATE), {})}
+
+    train("Winner", data_dir=str(tmp_path), models_dir=str(tmp_path), models=models)
+    assert isinstance(captured["final_estimator"], GradientBoostingClassifier)
+    assert captured["passthrough"] is False
+
+    captured.clear()
+    train(
+        "Winner",
+        data_dir=str(tmp_path),
+        models_dir=str(tmp_path),
+        models=models,
+        final_estimator=LogisticRegression(),
+        passthrough=True,
+    )
+    assert isinstance(captured["final_estimator"], LogisticRegression)
+    assert captured["passthrough"] is True

--- a/ufc_predictor/config.py
+++ b/ufc_predictor/config.py
@@ -1,3 +1,9 @@
 """Project configuration constants."""
 
+from sklearn.linear_model import LogisticRegression
+
 MODEL_VERSION = "1.0"
+
+# Default meta-model used by the stacking classifier. Can be overridden when
+# calling :func:`ufc_predictor.train`.
+STACKING_FINAL_ESTIMATOR = LogisticRegression()

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -15,6 +15,7 @@ import json
 
 import joblib
 import pandas as pd
+from sklearn.base import ClassifierMixin
 from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier, StackingClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score, roc_auc_score
@@ -23,7 +24,7 @@ from sklearn.impute import SimpleImputer
 from sklearn.svm import SVC
 from sklearn.preprocessing import LabelEncoder
 
-from ufc_predictor.config import MODEL_VERSION
+from ufc_predictor.config import MODEL_VERSION, STACKING_FINAL_ESTIMATOR
 
 RANDOM_STATE = 42
 
@@ -56,7 +57,8 @@ def train(
     extended_search: bool = False,
     grid_overrides: dict | None = None,
     cv_splits: int = 5,
-    final_estimator: LogisticRegression = LogisticRegression(),
+    final_estimator: ClassifierMixin | None = None,
+    passthrough: bool = False,
 ):
     """Entrena modelos base y un stacking final para ``target_column``.
 
@@ -94,8 +96,11 @@ def train(
         Número de particiones para la validación cruzada (se reduce a 2 si
         ``fast_mode`` es ``True``).
     final_estimator:
-        Estimador final del stacking. Por defecto se utiliza
-        ``LogisticRegression()``.
+        Estimador final del stacking. Por defecto se utiliza el definido en
+        ``ufc_predictor.config.STACKING_FINAL_ESTIMATOR``.
+    passthrough:
+        Si es ``True`` el meta-modelo recibe también las características
+        originales además de las predicciones de los modelos base.
 
     Notes
     -----
@@ -109,6 +114,9 @@ def train(
     if models_dir is None:
         models_dir = os.path.abspath(os.path.join("models", MODEL_VERSION))
     os.makedirs(models_dir, exist_ok=True)
+
+    if final_estimator is None:
+        final_estimator = STACKING_FINAL_ESTIMATOR
 
     try:
         fight_stats = pd.read_csv(os.path.join(data_dir, "fight_stats.csv"))
@@ -395,6 +403,7 @@ def train(
         final_estimator=final_estimator,
         cv=cv,
         n_jobs=-1,
+        passthrough=passthrough,
     )
     stacking.fit(X_train, y_train)
     joblib.dump(stacking, os.path.join(models_dir, f"stacking_{target_suffix}.pkl"))


### PR DESCRIPTION
## Summary
- allow configuring stacking final estimator via `config.py` or `train` argument
- expose passthrough flag in `train` and document usage
- test passthrough forwarding and final estimator override

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0dc1ec0bc8324b62a4c4476caffa5