### PR TITLE
feat: expose stacking options

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,19 @@ Para entrenar el modelo del ganador del combate:
 python entrenamiento_winner.py
 ```
 
+Ambos scripts aceptan parámetros opcionales mediante variables de entorno:
+
+* `SEARCH_METHOD`: estrategia de búsqueda (`grid`, `random` o `bayes`).
+* `FINAL_ESTIMATOR`: meta-modelo del stacking (`logistic` o `gb`).
+* `STACK_PASSTHROUGH`: si vale `1`/`true` el meta-modelo recibe también las
+  características originales.
+
+Ejemplo:
+
+```bash
+SEARCH_METHOD=random STACK_PASSTHROUGH=1 FINAL_ESTIMATOR=gb python entrenamiento.py
+```
+
 Tras cada entrenamiento se genera `data/mispredictions_{target}.csv` con las filas
 del dataset original que el modelo predijo de forma incorrecta. Revisa este
 archivo para detectar registros erróneos o columnas mal procesadas; corrige esos

--- a/entrenamiento.py
+++ b/entrenamiento.py
@@ -29,11 +29,25 @@ if __name__ == "__main__":
     nombres = [m.strip() for m in model_names.split(",") if m.strip()] if model_names else None
     fast = os.getenv("FAST_MODE", "").lower() in ("1", "true", "yes")
     extended = os.getenv("EXTENDED_SEARCH", "").lower() in ("1", "true", "yes")
+    # Nuevos parámetros opcionales: método de búsqueda, estimador final y passthrough
+    search_method = os.getenv("SEARCH_METHOD", "grid")
+    passthrough = os.getenv("STACK_PASSTHROUGH", "").lower() in ("1", "true", "yes")
+
+    final_name = os.getenv("FINAL_ESTIMATOR")
+    final_estimator = None
+    if final_name:
+        final_name = final_name.lower()
+        if final_name == "logistic":
+            final_estimator = LogisticRegression(random_state=RANDOM_STATE)
+        elif final_name == "gb":
+            final_estimator = GradientBoostingClassifier(random_state=RANDOM_STATE)
 
     train(
         "Method",
         model_names=nombres,
         fast_mode=fast,
         extended_search=extended,
-
+        search_method=search_method,
+        final_estimator=final_estimator,
+        passthrough=passthrough,
     )

--- a/entrenamiento_winner.py
+++ b/entrenamiento_winner.py
@@ -29,10 +29,25 @@ if __name__ == "__main__":
     nombres = [m.strip() for m in model_names.split(",") if m.strip()] if model_names else None
     fast = os.getenv("FAST_MODE", "").lower() in ("1", "true", "yes")
     extended = os.getenv("EXTENDED_SEARCH", "").lower() in ("1", "true", "yes")
+    # Parámetros adicionales para controlar el stacking y la búsqueda
+    search_method = os.getenv("SEARCH_METHOD", "grid")
+    passthrough = os.getenv("STACK_PASSTHROUGH", "").lower() in ("1", "true", "yes")
+
+    final_name = os.getenv("FINAL_ESTIMATOR")
+    final_estimator = None
+    if final_name:
+        final_name = final_name.lower()
+        if final_name == "logistic":
+            final_estimator = LogisticRegression(random_state=RANDOM_STATE)
+        elif final_name == "gb":
+            final_estimator = GradientBoostingClassifier(random_state=RANDOM_STATE)
 
     train(
         "Winner",
         model_names=nombres,
         fast_mode=fast,
         extended_search=extended,
+        search_method=search_method,
+        final_estimator=final_estimator,
+        passthrough=passthrough,
     )

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -28,6 +28,11 @@ from sklearn.model_selection import (
 from sklearn.impute import SimpleImputer
 from sklearn.svm import SVC
 from sklearn.preprocessing import LabelEncoder
+from sklearn.ensemble import (
+    GradientBoostingClassifier,
+    RandomForestClassifier,
+    StackingClassifier,
+)
 
 from ufc_predictor.config import MODEL_VERSION, STACKING_FINAL_ESTIMATOR
 
@@ -61,6 +66,9 @@ def train(
     fast_mode: bool = False,
     extended_search: bool = False,
     grid_overrides: dict | None = None,
+    search_method: str = "grid",
+    final_estimator=None,
+    passthrough: bool = False,
     cv_splits: int = 5,
 
 ):
@@ -96,9 +104,6 @@ def train(
         deben coincidir con las del diccionario ``models`` y sus valores se
         combinan con los grids por defecto, sustituyendo o ampliando los
         existentes.
-    cv_splits:
-        Número de particiones para la validación cruzada (se reduce a 2 si
-        ``fast_mode`` es ``True``).
     search_method:
         Estrategia de búsqueda de hiperparámetros. Puede ser ``"grid"`` para
         :class:`~sklearn.model_selection.GridSearchCV`, ``"random"`` para
@@ -110,6 +115,9 @@ def train(
     passthrough:
         Si es ``True`` el meta-modelo recibe también las características
         originales además de las predicciones de los modelos base.
+    cv_splits:
+        Número de particiones para la validación cruzada (se reduce a 2 si
+        ``fast_mode`` es ``True``).
 
     Notes
     -----
@@ -125,6 +133,7 @@ def train(
     os.makedirs(models_dir, exist_ok=True)
 
     if final_estimator is None:
+        # Mantener el estimador por defecto si no se especifica otro
         final_estimator = STACKING_FINAL_ESTIMATOR
 
     try:


### PR DESCRIPTION
## Summary
- allow selecting hyperparameter search method, meta-estimator and passthrough in `train`
- make training scripts configurable via environment variables
- document new stacking options in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0ea0380e483249674541badc6a791