### PR TITLE
Elimina modo rápido y usa cinco modelos base

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,11 @@ ya que contiene las características utilizadas para el entrenamiento.
 Puedes ajustar el comportamiento mediante variables de entorno:
 
 - `MODEL_NAMES`: lista separada por comas de modelos a entrenar.
-- `FAST_MODE=1`: usa un subconjunto de datos y grids mínimos para ejecuciones rápidas.
 - `EXTENDED_SEARCH=1`: activa grids de hiperparámetros más amplios para una búsqueda exhaustiva.
-  Si ambos flags se usan, `FAST_MODE` tiene prioridad.
+
+El stacking por defecto entrena cinco modelos base (XGBoost, LightGBM, CatBoost,
+RandomForest y GradientBoosting) cuyos resultados se combinan mediante una
+regresión logística.
 
 ### Configurar el meta-modelo
 

--- a/entrenamiento.py
+++ b/entrenamiento.py
@@ -27,7 +27,6 @@ if __name__ == "__main__":
 
     model_names = os.getenv("MODEL_NAMES")
     nombres = [m.strip() for m in model_names.split(",") if m.strip()] if model_names else None
-    fast = os.getenv("FAST_MODE", "").lower() in ("1", "true", "yes")
     extended = os.getenv("EXTENDED_SEARCH", "").lower() in ("1", "true", "yes")
     # Nuevos parámetros opcionales: método de búsqueda, estimador final y passthrough
     search_method = os.getenv("SEARCH_METHOD", "grid")
@@ -45,7 +44,6 @@ if __name__ == "__main__":
     train(
         "Method",
         model_names=nombres,
-        fast_mode=fast,
         extended_search=extended,
         search_method=search_method,
         final_estimator=final_estimator,

--- a/entrenamiento_winner.py
+++ b/entrenamiento_winner.py
@@ -27,7 +27,6 @@ if __name__ == "__main__":
 
     model_names = os.getenv("MODEL_NAMES")
     nombres = [m.strip() for m in model_names.split(",") if m.strip()] if model_names else None
-    fast = os.getenv("FAST_MODE", "").lower() in ("1", "true", "yes")
     extended = os.getenv("EXTENDED_SEARCH", "").lower() in ("1", "true", "yes")
     # Parámetros adicionales para controlar el stacking y la búsqueda
     search_method = os.getenv("SEARCH_METHOD", "grid")
@@ -45,7 +44,6 @@ if __name__ == "__main__":
     train(
         "Winner",
         model_names=nombres,
-        fast_mode=fast,
         extended_search=extended,
         search_method=search_method,
         final_estimator=final_estimator,

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -97,13 +97,12 @@ def test_extended_search_expands_params(tmp_path, monkeypatch):
         "Winner",
         data_dir=str(tmp_path),
         models_dir=str(tmp_path),
-        model_names=["LogisticRegression"],
+        model_names=["RandomForest"],
         extended_search=True,
     )
 
-    assert len(captured["params"]["C"]) > 3
-    assert 0.01 in captured["params"]["C"]
-    assert 100 in captured["params"]["C"]
+    assert len(captured["params"]["n_estimators"]) > 2
+    assert 300 in captured["params"]["n_estimators"]
 
 
 def test_passthrough_and_final_estimator(tmp_path, monkeypatch):

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -17,7 +17,6 @@ import math
 import joblib
 import pandas as pd
 
-from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score, roc_auc_score
 from sklearn.model_selection import (
     GridSearchCV,
@@ -26,7 +25,6 @@ from sklearn.model_selection import (
     train_test_split,
 )
 from sklearn.impute import SimpleImputer
-from sklearn.svm import SVC
 from sklearn.preprocessing import LabelEncoder
 from sklearn.ensemble import (
     GradientBoostingClassifier,
@@ -63,7 +61,6 @@ def train(
     models_dir: str | None = None,
     models: dict | None = None,
     model_names: list[str] | None = None,
-    fast_mode: bool = False,
     extended_search: bool = False,
     grid_overrides: dict | None = None,
     search_method: str = "grid",
@@ -91,11 +88,6 @@ def train(
         Lista opcional con los nombres de modelos a ejecutar. Los nombres
         deben coincidir con las claves del diccionario ``models``. Si es
         ``None`` se entrenan todos los modelos disponibles.
-    fast_mode:
-        Si es ``True`` se ejecuta un entrenamiento reducido pensado para
-        ejecuciones rápidas: solo se entrenan modelos livianos con un
-        único conjunto de hiperparámetros, se usa una fracción pequeña de
-        los datos y la validación cruzada utiliza dos particiones.
     extended_search:
         Activa grids de hiperparámetros más amplios para una búsqueda más
         exhaustiva a costa de mayor tiempo de entrenamiento.
@@ -116,16 +108,14 @@ def train(
         Si es ``True`` el meta-modelo recibe también las características
         originales además de las predicciones de los modelos base.
     cv_splits:
-        Número de particiones para la validación cruzada (se reduce a 2 si
-        ``fast_mode`` es ``True``).
+        Número de particiones para la validación cruzada.
 
     Notes
     -----
     Se requiere al menos ``min(cv_splits, min_clase)`` muestras por clase para
-    la validación estratificada (``min(2, min_clase)`` si se activa
-    ``fast_mode``) donde ``min_clase`` es la cantidad mínima de ejemplos por
-    clase en ``y``. Si alguna clase tiene menos ejemplos, aumenta los datos de
-    entrenamiento.
+    la validación estratificada, donde ``min_clase`` es la cantidad mínima de
+    ejemplos por clase en ``y``. Si alguna clase tiene menos ejemplos, aumenta
+    los datos de entrenamiento.
     """
 
     if models_dir is None:
@@ -253,139 +243,96 @@ def train(
         os.path.join(models_dir, f"label_encoder_{target_suffix}.pkl"),
     )
 
-    if fast_mode:
-        X = X.sample(frac=0.1, random_state=RANDOM_STATE)
-        y = y.loc[X.index]
-
     min_clase = y.value_counts().min()
 
-    if models is None or fast_mode:
-        if fast_mode:
+    if models is None:
+        from lightgbm import LGBMClassifier
+        from xgboost import XGBClassifier
+        from catboost import CatBoostClassifier
+
+        if extended_search:
             models = {
+                "XGBoost": (
+                    XGBClassifier(random_state=RANDOM_STATE),
+                    {
+                        "learning_rate": [0.05, 0.1, 0.2],
+                        "n_estimators": [50, 100, 200],
+                        "max_depth": [3, 5, 7],
+                    },
+                ),
+                "LightGBM": (
+                    LGBMClassifier(random_state=RANDOM_STATE),
+                    {
+                        "learning_rate": [0.05, 0.1, 0.2],
+                        "n_estimators": [50, 100, 200],
+                        "max_depth": [3, 5, 7],
+                    },
+                ),
+                "CatBoost": (
+                    CatBoostClassifier(verbose=0, random_state=RANDOM_STATE),
+                    {
+                        "learning_rate": [0.01, 0.1],
+                        "iterations": [50, 100, 200],
+                    },
+                ),
                 "RandomForest": (
                     RandomForestClassifier(random_state=RANDOM_STATE),
                     {
-                        "n_estimators": [50],
-                        "max_depth": [10],
-                        "min_samples_split": [2],
+                        "n_estimators": [100, 200, 300],
+                        "max_depth": [None, 10, 20, 30],
+                        "min_samples_split": [2, 5, 10],
                     },
                 ),
-                "LogisticRegression": (
-                    LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
-                    {"C": [1], "solver": ["lbfgs"]},
+                "GradientBoosting": (
+                    GradientBoostingClassifier(random_state=RANDOM_STATE),
+                    {
+                        "learning_rate": [0.05, 0.1],
+                        "n_estimators": [100, 200],
+                        "max_depth": [3, 5, 7],
+                    },
                 ),
             }
-            model_names = ["LogisticRegression", "RandomForest"]
         else:
-            from lightgbm import LGBMClassifier
-            from xgboost import XGBClassifier
-            from catboost import CatBoostClassifier
-
-            if extended_search:
-                models = {
-                    "XGBoost": (
-                        XGBClassifier(random_state=RANDOM_STATE),
-                        {
-                            "learning_rate": [0.05, 0.1, 0.2],
-                            "n_estimators": [50, 100, 200],
-                            "max_depth": [3, 5, 7],
-                        },
-                    ),
-                    "LightGBM": (
-                        LGBMClassifier(random_state=RANDOM_STATE),
-                        {
-                            "learning_rate": [0.05, 0.1, 0.2],
-                            "n_estimators": [50, 100, 200],
-                            "max_depth": [3, 5, 7],
-                        },
-                    ),
-                    "CatBoost": (
-                        CatBoostClassifier(verbose=0, random_state=RANDOM_STATE),
-                        {
-                            "learning_rate": [0.01, 0.1],
-                            "iterations": [50, 100, 200],
-                        },
-                    ),
-                    "RandomForest": (
-                        RandomForestClassifier(random_state=RANDOM_STATE),
-                        {
-                            "n_estimators": [100, 200, 300],
-                            "max_depth": [None, 10, 20, 30],
-                            "min_samples_split": [2, 5, 10],
-                        },
-                    ),
-                    "GradientBoosting": (
-                        GradientBoostingClassifier(random_state=RANDOM_STATE),
-                        {
-                            "learning_rate": [0.05, 0.1],
-                            "n_estimators": [100, 200],
-                            "max_depth": [3, 5, 7],
-                        },
-                    ),
-                    "LogisticRegression": (
-                        LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
-                        {
-                            "C": [0.01, 0.1, 1, 10, 100],
-                            "solver": ["lbfgs", "liblinear"],
-                        },
-                    ),
-                    "SVC": (
-                        SVC(probability=True, random_state=RANDOM_STATE),
-                        {
-                            "C": [0.1, 1, 10, 100],
-                            "kernel": ["linear", "rbf", "poly"],
-                        },
-                    ),
-                }
-            else:
-                # Hyperparameter grids are intentionally small to keep CI runtime low.
-                # Con ``n_splits=3`` el grid más grande genera <50 ajustes.
-                models = {
-                    "XGBoost": (
-                        XGBClassifier(random_state=RANDOM_STATE),
-                        {
-                            "learning_rate": [0.1],
-                            "n_estimators": [50, 100],
-                            "max_depth": [3, 5],
-                        },
-                    ),
-                    "LightGBM": (
-                        LGBMClassifier(random_state=RANDOM_STATE),
-                        {
-                            "learning_rate": [0.1],
-                            "n_estimators": [50, 100],
-                            "max_depth": [3, 5],
-                        },
-                    ),
-                    "CatBoost": (
-                        CatBoostClassifier(verbose=0, random_state=RANDOM_STATE),
-                        {"learning_rate": [0.1], "iterations": [50, 100]},
-                    ),
-                    "RandomForest": (
-                        RandomForestClassifier(random_state=RANDOM_STATE),
-                        {
-                            "n_estimators": [50, 100],
-                            "max_depth": [10, 20],
-                            "min_samples_split": [2, 5],
-                        },
-                    ),
-                    "GradientBoosting": (
-                        GradientBoostingClassifier(random_state=RANDOM_STATE),
-                        {
-                            "learning_rate": [0.1],
-                            "n_estimators": [50, 100],
-                            "max_depth": [3, 5],
-                        },
-                    ),
-                    "LogisticRegression": (
-                        LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
-                        {"C": [0.1, 1, 10], "solver": ["lbfgs", "liblinear"]},
-                    ),
-                    "SVC": (
-                        SVC(probability=True, random_state=RANDOM_STATE),
-                        {"C": [0.1, 1, 10], "kernel": ["linear", "rbf"]},
-                    ),
-                }
+            # Hyperparameter grids are intentionally small to keep CI runtime low.
+            # Con ``n_splits=3`` el grid más grande genera <50 ajustes.
+            models = {
+                "XGBoost": (
+                    XGBClassifier(random_state=RANDOM_STATE),
+                    {
+                        "learning_rate": [0.1],
+                        "n_estimators": [50, 100],
+                        "max_depth": [3, 5],
+                    },
+                ),
+                "LightGBM": (
+                    LGBMClassifier(random_state=RANDOM_STATE),
+                    {
+                        "learning_rate": [0.1],
+                        "n_estimators": [50, 100],
+                        "max_depth": [3, 5],
+                    },
+                ),
+                "CatBoost": (
+                    CatBoostClassifier(verbose=0, random_state=RANDOM_STATE),
+                    {"learning_rate": [0.1], "iterations": [50, 100]},
+                ),
+                "RandomForest": (
+                    RandomForestClassifier(random_state=RANDOM_STATE),
+                    {
+                        "n_estimators": [50, 100],
+                        "max_depth": [10, 20],
+                        "min_samples_split": [2, 5],
+                    },
+                ),
+                "GradientBoosting": (
+                    GradientBoostingClassifier(random_state=RANDOM_STATE),
+                    {
+                        "learning_rate": [0.1],
+                        "n_estimators": [50, 100],
+                        "max_depth": [3, 5],
+                    },
+                ),
+            }
 
     if model_names:
         nombres = {n.lower() for n in model_names}
@@ -402,7 +349,7 @@ def train(
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, random_state=RANDOM_STATE
     )
-    n_splits = min(cv_splits if not fast_mode else 2, min_clase)
+    n_splits = min(cv_splits, min_clase)
     # Se requieren al menos ``n_splits`` muestras por clase o debes aumentar los datos.
     cv = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=RANDOM_STATE)
     mejores = []


### PR DESCRIPTION
## Summary
- Elimina el parámetro `fast_mode` y su lógica asociada para que el entrenamiento siempre use el conjunto completo de datos.
- Ajusta el entrenamiento por defecto a cinco modelos base (XGBoost, LightGBM, CatBoost, RandomForest y GradientBoosting) y actualiza la documentación.
- Actualiza los scripts y pruebas para reflejar la ausencia de `FAST_MODE`.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0f2e7f1648324ac81e20db2554e9f