### PR TITLE
Include logistic regression and SVC in stacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ El flujo de trabajo incluye desde el web scraping de datos de peleadores y comba
 - Pandas
 - NumPy
 - Scikit-learn
-- XGBoost, LightGBM, CatBoost
+- XGBoost, LightGBM, CatBoost, RandomForest, GradientBoosting, LogisticRegression, SVC
 - MySQL (AWS RDS)
 - Streamlit
 - BeautifulSoup4 (Web Scraping)
@@ -97,9 +97,9 @@ Puedes ajustar el comportamiento mediante variables de entorno:
 - `MODEL_NAMES`: lista separada por comas de modelos a entrenar.
 - `EXTENDED_SEARCH=1`: activa grids de hiperparámetros más amplios para una búsqueda exhaustiva.
 
-El stacking por defecto entrena cinco modelos base (XGBoost, LightGBM, CatBoost,
-RandomForest y GradientBoosting) cuyos resultados se combinan mediante una
-regresión logística.
+El stacking por defecto entrena siete modelos base (XGBoost, LightGBM,
+CatBoost, RandomForest, GradientBoosting, LogisticRegression y SVC) cuyos
+resultados se combinan mediante una regresión logística.
 
 ### Configurar el meta-modelo
 

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -31,6 +31,8 @@ from sklearn.ensemble import (
     RandomForestClassifier,
     StackingClassifier,
 )
+from sklearn.linear_model import LogisticRegression
+from sklearn.svm import SVC
 
 from ufc_predictor.config import MODEL_VERSION, STACKING_FINAL_ESTIMATOR
 
@@ -291,6 +293,18 @@ def train(
                         "max_depth": [3, 5, 7],
                     },
                 ),
+                "LogisticRegression": (
+                    LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
+                    {"C": [0.01, 0.1, 1.0, 10]},
+                ),
+                "SVC": (
+                    SVC(probability=True, random_state=RANDOM_STATE),
+                    {
+                        "C": [0.1, 1.0, 10],
+                        "kernel": ["linear", "rbf"],
+                        "gamma": ["scale", "auto"],
+                    },
+                ),
             }
         else:
             # Hyperparameter grids are intentionally small to keep CI runtime low.
@@ -331,6 +345,14 @@ def train(
                         "n_estimators": [50, 100],
                         "max_depth": [3, 5],
                     },
+                ),
+                "LogisticRegression": (
+                    LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
+                    {"C": [0.1, 1.0]},
+                ),
+                "SVC": (
+                    SVC(probability=True, random_state=RANDOM_STATE),
+                    {"C": [0.5, 1.0], "kernel": ["rbf"]},
                 ),
             }
 


### PR DESCRIPTION
## Summary
- add LogisticRegression and SVC as default base estimators in training
- document the expanded set of models used in stacking
- clarify README technologies list to include all seven stacking models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0f79ecdc4832489327bf7ab003547