### PR TITLE
Improve logistic regression convergence

### DIFF
--- a/entrenamiento.py
+++ b/entrenamiento.py
@@ -5,6 +5,8 @@ import sys
 
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 
 from ufc_predictor.train import RANDOM_STATE, train
 
@@ -37,7 +39,15 @@ if __name__ == "__main__":
     if final_name:
         final_name = final_name.lower()
         if final_name == "logistic":
-            final_estimator = LogisticRegression(random_state=RANDOM_STATE)
+            final_estimator = Pipeline(
+                [
+                    ("scaler", StandardScaler()),
+                    (
+                        "logreg",
+                        LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
+                    ),
+                ]
+            )
         elif final_name == "gb":
             final_estimator = GradientBoostingClassifier(random_state=RANDOM_STATE)
 

--- a/entrenamiento_winner.py
+++ b/entrenamiento_winner.py
@@ -5,6 +5,8 @@ import sys
 
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 
 from ufc_predictor.train import RANDOM_STATE, train
 
@@ -37,7 +39,15 @@ if __name__ == "__main__":
     if final_name:
         final_name = final_name.lower()
         if final_name == "logistic":
-            final_estimator = LogisticRegression(random_state=RANDOM_STATE)
+            final_estimator = Pipeline(
+                [
+                    ("scaler", StandardScaler()),
+                    (
+                        "logreg",
+                        LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
+                    ),
+                ]
+            )
         elif final_name == "gb":
             final_estimator = GradientBoostingClassifier(random_state=RANDOM_STATE)
 

--- a/ufc_predictor/config.py
+++ b/ufc_predictor/config.py
@@ -1,9 +1,16 @@
 """Project configuration constants."""
 
 from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 
 MODEL_VERSION = "1.0"
 
 # Default meta-model used by the stacking classifier. Can be overridden when
 # calling :func:`ufc_predictor.train`.
-STACKING_FINAL_ESTIMATOR = LogisticRegression()
+STACKING_FINAL_ESTIMATOR = Pipeline(
+    [
+        ("scaler", StandardScaler()),
+        ("logreg", LogisticRegression(max_iter=1000, random_state=42)),
+    ]
+)

--- a/ufc_predictor/train.py
+++ b/ufc_predictor/train.py
@@ -251,6 +251,8 @@ def train(
         from lightgbm import LGBMClassifier
         from xgboost import XGBClassifier
         from catboost import CatBoostClassifier
+        from sklearn.pipeline import Pipeline
+        from sklearn.preprocessing import StandardScaler
 
         if extended_search:
             models = {
@@ -294,8 +296,18 @@ def train(
                     },
                 ),
                 "LogisticRegression": (
-                    LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
-                    {"C": [0.01, 0.1, 1.0, 10]},
+                    Pipeline(
+                        [
+                            ("scaler", StandardScaler()),
+                            (
+                                "logreg",
+                                LogisticRegression(
+                                    max_iter=1000, random_state=RANDOM_STATE
+                                ),
+                            ),
+                        ]
+                    ),
+                    {"logreg__C": [0.01, 0.1, 1.0, 10]},
                 ),
                 "SVC": (
                     SVC(probability=True, random_state=RANDOM_STATE),
@@ -347,8 +359,18 @@ def train(
                     },
                 ),
                 "LogisticRegression": (
-                    LogisticRegression(max_iter=1000, random_state=RANDOM_STATE),
-                    {"C": [0.1, 1.0]},
+                    Pipeline(
+                        [
+                            ("scaler", StandardScaler()),
+                            (
+                                "logreg",
+                                LogisticRegression(
+                                    max_iter=1000, random_state=RANDOM_STATE
+                                ),
+                            ),
+                        ]
+                    ),
+                    {"logreg__C": [0.1, 1.0]},
                 ),
                 "SVC": (
                     SVC(probability=True, random_state=RANDOM_STATE),


### PR DESCRIPTION
## Summary
- scale features for logistic regression base models using `StandardScaler`
- raise `max_iter` and wrap stacking final estimator in a scaler+logistic pipeline
- support scaled logistic regression meta-model in training scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0fadcd9788324b5404c441b937a14